### PR TITLE
Fix for string index error on insertion

### DIFF
--- a/src/main/java/com/astrazeneca/vardict/VarDict.java
+++ b/src/main/java/com/astrazeneca/vardict/VarDict.java
@@ -960,7 +960,7 @@ public class VarDict {
                 Variant rref = getVarMaybe(vars, p, ref);
                 for (int i = 0; i < vvar.size(); i++) {
                     Variant vref = vvar.get(i);
-                    if (vref.refallele.contains("N")) {
+                    if (vref.refallele.contains("N") || vref.refallele.length() == 0) {
                         continue;
                     }
                     String vartype = varType(vref.refallele, vref.varallele);


### PR DESCRIPTION
Thanks much for the quick 1.4.1 fix. We've been running VarDictJava on a lot more real samples and found another issue on some insertion edge cases, which generate an index out of bounds exception:
```
Exception in thread "main" java.lang.StringIndexOutOfBoundsException: String index out of range: 0
        at java.lang.String.charAt(String.java:658)
        at com.astrazeneca.vardict.VarDict.varType(VarDict.java:5903)
        at com.astrazeneca.vardict.VarDict.vardict(VarDict.java:966)
        at com.astrazeneca.vardict.VarDict.vardictNotParallel(VarDict.java:305)
        at com.astrazeneca.vardict.VarDict.nonAmpVardict(VarDict.java:257)
        at com.astrazeneca.vardict.VarDict.start(VarDict.java:68)
        at com.astrazeneca.vardict.Main.run(Main.java:134)
        at com.astrazeneca.vardict.Main.main(Main.java:25)
```
VarDict perl emits warning messages on the same input but does not fail on
same input. Here is a small reproducible test case:

https://s3.amazonaws.com/chapmanb/az/vardict-outofbounds.tar.gz

The fix skips checking vartype if we have an empty reference sequence,
avoiding the problem. Thanks much.