### PR TITLE
When altering soft-clipping at the end of the read, don't attempt to …

### DIFF
--- a/src/main/java/com/astrazeneca/vardict/VarDict.java
+++ b/src/main/java/com/astrazeneca/vardict/VarDict.java
@@ -6207,7 +6207,7 @@ public class VarDict {
                     cigarStr = D_M_D_S_END.matcher(cigarStr).replaceFirst(mch + "M");
                 }
             }
-            if (rn == 0) {
+            else if (rn == 0) {
                 while (rn < mch && isHasAndNotEquals(ref, refoff - rn - 1, querySeq, rdoff - rn - 1)) {
                     rn++;
                 }


### PR DESCRIPTION
…trim back the read after any soft-clipping was removed.

This is an attempt to fix [issue 38](https://github.com/AstraZeneca-NGS/VarDictJava/issues/38).  The problem appears, I think, to be the code around line 6200-6210 where VarDict is trying to adjust the soft-clipping at the end of the read.  Prior to this commit, if less than three but greater than zero soft-clipped bases matched the reference, the code would enter the `if` branch on line 6201 and bump `mch` up by one and `soft` down by one.  It does _not_ however adjust `refoff` and `rdoff`, which if they are to be used again should be adjusted in sync.  

After this, the code would then enter the `if` branch on line 6210, which uses all four of `mch`, `soft`, `refoff` and `rdoff` and examine the read to see if it needed trimming back.  Since the variables are out of sync, when there are enough mismatches the code can go beyond `0` for `rdoff - rn - 1`, and cause the `StringIndexOutOfBoundsException`

The simplist fix is to turn the `if` into an `else if` on line 6210 since why would you trim back a `M` segment you just extended?