### PR TITLE
Fixed handling of leading and trailing insertions in cigar strings.

### DIFF
--- a/src/main/java/com/astrazeneca/vardict/VarDict.java
+++ b/src/main/java/com/astrazeneca/vardict/VarDict.java
@@ -1446,6 +1446,7 @@ public class VarDict {
                         continue;
                     }
 
+                    cleanupCigar(record);
 
                     final String mrnm = getMrnm(record);
 
@@ -2520,6 +2521,58 @@ public class VarDict {
                 && record.getMateNegativeStrandFlag()
                 && record.getMateReferenceName().equals(record.getReferenceName())
                 && record.getMateAlignmentStart() <= record.getAlignmentEnd();
+    }
+
+    /**
+     * Attempts to clean up a CIGAR string so that edge cases are avoided in the rest of the code.
+     * Specifically this method will remove leading or trailing hard-clips, and then convert
+     * leading or trailing insertions into soft-clips.
+     */
+    private static void cleanupCigar(final SAMRecord rec) {
+        if (rec.getCigar() != null) {
+            final List<CigarElement> elems = new ArrayList<>(rec.getCigar().getCigarElements());
+
+            // First leading elements
+            {
+                final ListIterator<CigarElement> iterator = elems.listIterator();
+                boolean noMatchesYet = true;
+                while (iterator.hasNext() && noMatchesYet) {
+                    final CigarElement elem = iterator.next();
+                    if (elem.getOperator() == CigarOperator.INSERTION) {
+                        final CigarElement replacement = new CigarElement(elem.getLength(), CigarOperator.SOFT_CLIP);
+                        iterator.set(replacement);
+                    }
+                    else if (elem.getOperator() == CigarOperator.HARD_CLIP) {
+                        iterator.remove();
+                    }
+                    else if (elem.getOperator().consumesReadBases() && elem.getOperator().consumesReferenceBases()) {
+                        noMatchesYet = false;
+                    }
+                }
+            }
+
+            // Then trailing elements
+            {
+                final ListIterator<CigarElement> iterator = elems.listIterator(elems.size());
+                boolean noMatchesYet = true;
+                while (iterator.hasPrevious() && noMatchesYet) {
+                    final CigarElement elem = iterator.previous();
+                    if (elem.getOperator() == CigarOperator.INSERTION) {
+                        final CigarElement replacement = new CigarElement(elem.getLength(), CigarOperator.SOFT_CLIP);
+                        iterator.set(replacement);
+                    }
+                    else if (elem.getOperator() == CigarOperator.HARD_CLIP) {
+                        iterator.remove();
+                    }
+                    else if (elem.getOperator().consumesReadBases() && elem.getOperator().consumesReferenceBases()) {
+                        noMatchesYet = false;
+                    }
+                }
+            }
+
+            // And lastly replace the cigar
+            rec.setCigar(new Cigar(elems));
+        }
     }
 
     private static CigarOperator getCigarOperator(Cigar cigar, int ci) {


### PR DESCRIPTION
This PR provides a fix for #34.  It implements a new method that "cleans up the cigar string" on an existing `SAMRecord` prior to the record being used further by VarDictJava.  It removes hard-clipping from the Cigar string (since it's meaningless to VarDict) and then converts any "leading" and "trailing" insertions to softclips, where "leading"/"trailing" are defined as prior to encountering any bases that are aligned between read and reference, not just as the first operator.

Some examples of what the method does:
`10H90M` -> `90M`
`10I90M` -> `10S90M`
`10H5S5I90M` -> `5S5S90M` (could be made to -> `10S90M`, but I think it's fine as is)
`10H5S5I80M3I3S14H` -> `5S5S80M3S3S`

I'm not really sure what the testing procedure/policy is for VarDictJava.  I've run this on a couple of samples that were failing for me and it now appears to work as desired.  Is there some set of regression tests somewhere?
