### PR TITLE
StringIndexOutOfBoundsException in case of large deletion  

### DIFF
--- a/src/main/java/com/astrazeneca/vardict/Utils.java
+++ b/src/main/java/com/astrazeneca/vardict/Utils.java
@@ -77,7 +77,7 @@ public final class Utils {
 
     public static String substr(String string, int idx) {
         if (idx >= 0) {
-            return string.substring(idx);
+            return string.substring(Math.min(string.length(), idx));
         } else {
             return string.substring(Math.max(0, string.length() + idx));
         }


### PR DESCRIPTION
We`ve found that in Util method substr(String string, int idx) line 80 misses examination of incoming idx, which leads to StringIndexOutOfBoundsException e.g. in case of large deletion.
An overloaded method checks that index is valid (not < 0 and not > string.length) and if it is not true it uses 0 or string.length respectively. 
We propose to do the same in substr method.
@mjafin, @zhongwulai could you review please?