### PR TITLE
Reverse of sequence 5' in huge indels realignment

### DIFF
--- a/src/main/java/com/astrazeneca/vardict/VarDict.java
+++ b/src/main/java/com/astrazeneca/vardict/VarDict.java
@@ -3381,7 +3381,7 @@ public class VarDict {
                     System.err.printf("  Working lgins30: %s %s 3: %s %s 5: %s %s\n",
                             p3, p5, seq3, cnt3, new StringBuilder(seq5).reverse(), cnt5);
                 }
-                Tuple3<Integer, Integer, Integer> tpl = find35match(seq5, seq3, p5, p3, ref);
+                Tuple3<Integer, Integer, Integer> tpl = find35match(new StringBuilder(seq5).reverse().toString(), seq3, p5, p3, ref);
                 int bp5 = tpl._1;
                 int bp3 = tpl._2;
                 //length of match


### PR DESCRIPTION
**Description**
We have found that string for sequence 5' is passed to method `find35match()` in `realignlgins30()` in forward, not reverse order. This bug caused different problems associated with incorrect variations identification.
 
**Implementation**
We have added reverse to string `seq5'`. 

Moreover, we've made a test on other data and have figured out that 22 'variations' that disappeared from the output after the fix were not variations at all, except for several of them, which are controversial. 

Here's the examples of false positive cases:
- chr17:57351101: G -> GCTTAGGGATAATGATCATGAAATATTTTTTT - no such nucleotides in reads;
- chr3:195505742: G -> GACCTGTGGATACTGAGGAAAGGCTGGTGACAGGAAGAGGTCGTGGTGTC -  no such nucleotides in reads;
- chr2:61315554: G -> GGAAAAATCAATGTGAAATGTAGTAAATTAAAGAATATAGCTGCATTATAAAGTACACCAAA - softclip, mapping quality 0, 1 case (long change, not 1 nucleotide).

Possible variations:
- chr4:86018: TTTACAGGGTCCACAATCCACTGAATG ->CTTTAATAGGTCCACATCACTTAGTA - softclip, many changes (MNP), but mapping quality 3-60;
- chr1:13183237: CTCTTGTTTGCTC -> TCCTTGCTTGCAA - softclip, mapping quality from 10 to 40, C and T in 34%.

@zhongwulai, what do you think?

We have also compared VCF-file obtained as a result of our bugfix and initial VCF-file with giab VCF-file. The results below show that our changes have increased the number of correct variations identification.

**Comparison of initial-VCF vs. giab VCF and fixed-VCF vs. giab VCF:**
<table>
<tbody>   
<tr>
<th> </th>
<th colspan="2">Total truth</th>
<th colspan="2">Total query</th>
<th colspan="2">Total positive</th>
<th colspan="2">False positive</th>   
<th colspan="2">False negative</th>
</tr>
<tr>
<th>Type</th>
<th>Old</th>
<th>New</th>
<th>Old</th>   
<th>New</th>   
<th>Old</th>   
<th>New</th>   
<th>Old</th>   
<th>New</th>
<th>Old</th>   
<th>New</th> 
</tr>
<tr>
<td>Indels</td>
<td>433708</td>
<td>433708</td>
<td>4328</td>
<td>4328</td>
<td>2111</td>
<td>2111</td>
<td>2217</td>
<td>2217</td>
<td>431597</td>
<td>431597</td>
</tr>
<td>SNVs</td>
<td>3194096</td>
<td>3194096</td>
<td><b>54094</b></td>
<td><b>54096</b></td>
<td><b>54042</b></td>
<td><b>54044</b></td>
<td>52</td>
<td>52</td>
<td><b>3140054</b></td>
<td><b>3140052</b></td>
</tr>
<td>Records</td>
<td>3627296</td>
<td>3627296</td>
<td><b>58792</b></td>
<td><b>58794</b></td>
<td><b>56156</b></td>
<td><b>56158</b></td>
<td>2636</td>
<td>2636</td>
<td><b>3571140</b></td>
<td><b>3571138</b></td>
</tr>
<td>Others</td>
<td>873</td>
<td>873</td>
<td>54</td>
<td>54</td>
<td>3</td>
<td>3</td>
<td>51</td>
<td>51</td>
<td>870</td>
<td>870</td>
</tr>
</tbody>
</table>



The following changes will also fix the problem of appearing the 'A-A' variation in this issue: https://github.com/AstraZeneca-NGS/VarDictJava/issues/90 
