### PR TITLE
Quality scores too high

### DIFF
--- a/src/main/java/com/astrazeneca/vardict/modules/SAMFileParser.java
+++ b/src/main/java/com/astrazeneca/vardict/modules/SAMFileParser.java
@@ -35,7 +35,7 @@ public class SAMFileParser {
         } catch(IllegalArgumentException iae) {
         	// For consolidated reads the quality score can be outside the allowed ranges for proper character representation
         	// In this case we saturate at the highest value
-        	System.err.println("WARNING: Cannot get quality string for SAMRecord at " + record.getReferenceName() + ":" + record.getAlignmentStart() + ", record name: '" + record.getReadName()+"'. Capping qualities at " + SAMUtils.MAX_PHRED_SCORE);
+        	System.err.println("WARNING: Cannot get encode qualities for SAM entry at " + record.getReferenceName() + ":" + record.getAlignmentStart() + ", record name: '" + record.getReadName()+"'. Capping qualities at " + SAMUtils.MAX_PHRED_SCORE);
         	byte[] qs=record.getBaseQualities();
         	char[] qsChar = new char[qs.length];
         	for(int i=0 ; i < qs.length; i++) {

--- a/src/main/java/com/astrazeneca/vardict/modules/SAMFileParser.java
+++ b/src/main/java/com/astrazeneca/vardict/modules/SAMFileParser.java
@@ -35,7 +35,7 @@ public class SAMFileParser {
         } catch(IllegalArgumentException iae) {
         	// For consolidated reads the quality score can be outside the allowed ranges for proper character representation
         	// In this case we saturate at the highest value
-        	System.err.println("WARNING: Cannot get encode qualities for SAM entry at " + record.getReferenceName() + ":" + record.getAlignmentStart() + ", record name: '" + record.getReadName()+"'. Capping qualities at " + SAMUtils.MAX_PHRED_SCORE);
+        	System.err.println("WARNING: Cannot get encode qualities for SAM entry at " + record.getReferenceName() + ":" + record.getAlignmentStart() + ", record name: '" + record.getReadName()+"'. Qualities capped at " + SAMUtils.MAX_PHRED_SCORE);
         	byte[] qs=record.getBaseQualities();
         	char[] qsChar = new char[qs.length];
         	for(int i=0 ; i < qs.length; i++) {

--- a/src/main/java/com/astrazeneca/vardict/modules/SAMFileParser.java
+++ b/src/main/java/com/astrazeneca/vardict/modules/SAMFileParser.java
@@ -35,7 +35,7 @@ public class SAMFileParser {
         } catch(IllegalArgumentException iae) {
         	// For consolidated reads the quality score can be outside the allowed ranges for proper character representation
         	// In this case we saturate at the highest value
-        	System.err.println("WARNING: Cannot get quality string for SAMRecord " + record.getReferenceName() + ":" + record.getAlignmentStart() + ", " + record.getReadName());
+        	System.err.println("WARNING: Cannot get quality string for SAMRecord at " + record.getReferenceName() + ":" + record.getAlignmentStart() + ", record name: '" + record.getReadName()+"'. Capping qualities at " + SAMUtils.MAX_PHRED_SCORE);
         	byte[] qs=record.getBaseQualities();
         	char[] qsChar = new char[qs.length];
         	for(int i=0 ; i < qs.length; i++) {


### PR DESCRIPTION
This fixes with BAM files having quality scores over 96 (this happens when BAM files have collapsed UMI reads)
