### PR TITLE
Add Java 11 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,10 @@ cache:
     - $HOME/.gradle/wrapper/
 jdk:
   - oraclejdk8
-  - oraclejdk10
+  - oraclejdk11
   - openjdk8
   - openjdk10
+  - openjdk11
 script:
   - ./gradlew test jacocoTestReport
   - ./gradlew installDist

--- a/build.gradle
+++ b/build.gradle
@@ -27,12 +27,8 @@ dependencies {
     compile('com.github.samtools:htsjdk:2.8.0') {
         transitive = false
     }
-    // https://mvnrepository.com/artifact/org.powermock/powermock-module-junit4
-    testCompile group: 'org.powermock', name: 'powermock-api-mockito2', version: '2.0.0-beta.5'
-    testCompile group: 'org.powermock', name: 'powermock-module-testng', version: '2.0.0-beta.5'
+    testCompile 'org.mockito:mockito-core:2.23.0'
     testCompile 'org.testng:testng:6.9.13.6'
-    testCompile 'net.bytebuddy:byte-buddy:1.8.3'
-    testCompile 'net.bytebuddy:byte-buddy-agent:1.8.3'
 }
 
 mainClassName = "com.astrazeneca.vardict.Main"
@@ -74,4 +70,7 @@ jar {
     }
 }
 
+jacoco {
+    toolVersion = "0.8.2"
+}
 applicationDistribution.from('VarDict/teststrandbias.R','VarDict/testsomatic.R','VarDict/var2vcf_valid.pl','VarDict/var2vcf_paired.pl').into('bin')

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-bin.zip

--- a/src/main/java/com/astrazeneca/vardict/Main.java
+++ b/src/main/java/com/astrazeneca/vardict/Main.java
@@ -28,7 +28,11 @@ public class Main {
             if (cmd.getOptions().length == 0 || cmd.hasOption("H")) {
                 help(options);
             }
-            new Main().run(cmd);
+            Configuration conf = new Main().run(cmd);
+
+            ReferenceResource referenceResource = new ReferenceResource();
+            VarDict varDict = new VarDict(conf, referenceResource);
+            varDict.start();
         } catch (MissingOptionException e) {
             List<?> missingOptions = e.getMissingOptions();
             System.err.print("Missing required option(s): ");
@@ -45,7 +49,7 @@ public class Main {
         }
     }
 
-    private void run(CommandLine cmd) throws ParseException, IOException {
+    public Configuration run(CommandLine cmd) throws ParseException, IOException {
         Configuration conf = new Configuration();
 
         // -v is not used
@@ -150,8 +154,7 @@ public class Main {
         conf.threads = Math.max(readThreadsCount(cmd), 1);
         conf.referenceExtension = getIntValue(cmd, "Y", 1200);
 
-        VarDict.start(conf);
-
+        return conf;
     }
 
     private int readThreadsCount(CommandLine cmd) throws ParseException {
@@ -183,7 +186,7 @@ public class Main {
     }
 
     @SuppressWarnings("static-access")
-    private static Options buildOptions() {
+    public static Options buildOptions() {
         Options options = new Options();
         options.addOption("H", "?", false, "Print this help page");
         options.addOption("h", "header", false, "Print a header row describing columns");

--- a/src/main/java/com/astrazeneca/vardict/ReferenceResource.java
+++ b/src/main/java/com/astrazeneca/vardict/ReferenceResource.java
@@ -36,7 +36,7 @@ public class ReferenceResource {
      * @param end end position of region
      * @return array of nucleotide bases in the region of fasta
      */
-    public static String[] retrieveSubSeq(String fasta, String chr, int start, int end) {
+    public String[] retrieveSubSeq(String fasta, String chr, int start, int end) {
         IndexedFastaSequenceFile idx = fetchFasta(fasta);
         ReferenceSequence seq = idx.getSubsequenceAt(chr, start, end);
         byte[] bases = seq.getBases();
@@ -50,7 +50,7 @@ public class ReferenceResource {
      * @param conf Vardict Configuration
      * @return reference object contains sequence map: key - position, value - base and seed map
      */
-    public static Reference getREF(Region region, Map<String, Integer> chrs, Configuration conf) {
+    public Reference getREF(Region region, Map<String, Integer> chrs, Configuration conf) {
         Reference ref = new Reference();
         return getREF(region, chrs, conf, conf.referenceExtension, ref);
     }
@@ -64,7 +64,7 @@ public class ReferenceResource {
      * @param ref reference
      * @return reference object contains sequence map: key - position, value - base and seed map
      */
-    public static Reference getREF(Region region, Map<String, Integer> chrs, Configuration conf, int extension, Reference ref) {
+    public Reference getREF(Region region, Map<String, Integer> chrs, Configuration conf, int extension, Reference ref) {
         int sequenceStart = region.start - conf.numberNucleotideToExtend - extension < 1 ? 1
                 : region.start - conf.numberNucleotideToExtend - extension;
         int len = chrs.containsKey(region.chr) ? chrs.get(region.chr) : 0;
@@ -98,7 +98,6 @@ public class ReferenceResource {
 
             keySequence = substr(exon, i, Configuration.SEED_2);
             ref = addPositionsToSeedSequence(ref, sequenceStart, i, keySequence);
-
         }
 
         if (conf.y) {
@@ -116,7 +115,7 @@ public class ReferenceResource {
      * @param keySequence sequence length of SEED_1 parameter from chromosome
      * @return updated Reference
      */
-    public static Reference addPositionsToSeedSequence(Reference ref, int sequenceStart, int i, String keySequence) {
+    private static Reference addPositionsToSeedSequence(Reference ref, int sequenceStart, int i, String keySequence) {
         List<Integer> seedPositions = ref.seed.getOrDefault(keySequence, new ArrayList<>());
         seedPositions.add(i + sequenceStart);
         ref.seed.put(keySequence, seedPositions);

--- a/src/main/java/com/astrazeneca/vardict/VarDict.java
+++ b/src/main/java/com/astrazeneca/vardict/VarDict.java
@@ -15,7 +15,6 @@ import java.util.concurrent.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static com.astrazeneca.vardict.ReferenceResource.getREF;
 import static com.astrazeneca.vardict.modules.ToVarsBuilder.toVars;
 import static com.astrazeneca.vardict.variations.Variant.callingEmptySimpleVariant;
 import static com.astrazeneca.vardict.variations.Variant.joinEmptyVariantWithTcov;
@@ -30,13 +29,19 @@ import static java.lang.String.format;
 import static java.util.Collections.singletonList;
 
 public class VarDict {
+    ReferenceResource referenceResource;
+    Configuration conf;
 
+    public VarDict(Configuration conf, ReferenceResource referenceResource) {
+        this.referenceResource = referenceResource;
+        this.conf = conf;
+    }
     /**
      * The main method to start Vardict in any mode.
      * @param conf prepared configuration object from arguments
      * @throws IOException if BAM file can't be read
      */
-    public static void start(Configuration conf) throws IOException {
+    public void start() throws IOException {
         if (conf.printHeader) {
             System.out.println(join("\t",
                     "Sample", "Gene", "Chr", "Start", "End", "Ref", "Alt", "Depth", "AltDepth", "RefFwdReads",
@@ -54,7 +59,7 @@ public class VarDict {
         if (conf.regionOfInterest != null) {
             Region region = Region.buildRegion(conf.regionOfInterest, conf.numberNucleotideToExtend, chrs,
                     conf.isZeroBasedDefined() ? conf.zeroBased : false);
-            nonAmpVardict(singletonList(singletonList(region)), chrs, conf.ampliconBasedCalling, sample, samplem, conf);
+            nonAmpVardict(singletonList(singletonList(region)), chrs, conf.ampliconBasedCalling, sample, samplem, conf, referenceResource);
         } else {
             Tuple3<String, Boolean, List<String>> tpl = readBedFile(conf);
             String ampliconBasedCalling = tpl._1;
@@ -64,12 +69,12 @@ public class VarDict {
             if (ampliconBasedCalling != null) {
                 List<List<Region>> segs = toRegions(segraw, chrs, zeroBased != null ? zeroBased : false, conf.delimiter);
                 if (conf.threads == 1)
-                    ampVardictNotParallel(segs, chrs, ampliconBasedCalling, conf.bam.getBam1(), sample, conf);
+                    ampVardictNotParallel(segs, chrs, ampliconBasedCalling, conf.bam.getBam1(), sample, conf, referenceResource);
                 else
-                    ampVardictParallel(segs, chrs, ampliconBasedCalling, conf.bam.getBam1(), sample, conf);
+                    ampVardictParallel(segs, chrs, ampliconBasedCalling, conf.bam.getBam1(), sample, conf, referenceResource);
             } else {
                 List<List<Region>> regions = toRegions(segraw, chrs, zeroBased, conf);
-                nonAmpVardict(regions, chrs, null, sample, samplem, conf);
+                nonAmpVardict(regions, chrs, null, sample, samplem, conf, referenceResource);
             }
         }
     }
@@ -296,7 +301,8 @@ public class VarDict {
                                       String ampliconBasedCalling,
                                       String sample,
                                       String samplem,
-                                      Configuration conf) throws IOException {
+                                      Configuration conf,
+                                      ReferenceResource referenceResource) throws IOException {
 
         if (conf.bam.hasBam2()) {
             Tuple2<String, String> stpl = getSampleNames(sample, samplem, conf.bam.getBam1(), conf.bam.getBam2(),
@@ -304,14 +310,14 @@ public class VarDict {
             sample = stpl._1;
             samplem = stpl._2;
             if (conf.threads == 1)
-                somaticNotParallel(segs, chrs, ampliconBasedCalling, sample, samplem, conf);
+                somaticNotParallel(segs, chrs, ampliconBasedCalling, sample, samplem, conf, referenceResource);
             else
-                somaticParallel(segs, chrs, ampliconBasedCalling, sample, samplem, conf);
+                somaticParallel(segs, chrs, ampliconBasedCalling, sample, samplem, conf, referenceResource);
         } else {
             if (conf.threads == 1)
-                vardictNotParallel(segs, chrs, ampliconBasedCalling, sample, conf);
+                vardictNotParallel(segs, chrs, ampliconBasedCalling, sample, conf, referenceResource);
             else
-                vardictParallel(segs, chrs, ampliconBasedCalling, sample, conf);
+                vardictParallel(segs, chrs, ampliconBasedCalling, sample, conf, referenceResource);
         }
     }
 
@@ -319,7 +325,8 @@ public class VarDict {
                                         final Map<String, Integer> chrs,
                                         final String ampliconBasedCalling,
                                         final String sample,
-                                        final Configuration conf) {
+                                        final Configuration conf,
+                                        ReferenceResource referenceResource) {
         final ExecutorService executor = Executors.newFixedThreadPool(conf.threads);
         final BlockingQueue<Future<OutputStream>> toPrint = new LinkedBlockingQueue<>(10);
         executor.submit(new Runnable() {
@@ -329,7 +336,7 @@ public class VarDict {
                 try {
                     for (List<Region> list : segs) {
                         for (Region region : list) {
-                            toPrint.put(executor.submit(new VardictWorker(region, chrs, new HashSet<String>(), ampliconBasedCalling, sample, conf)));
+                            toPrint.put(executor.submit(new VardictWorker(region, chrs, new HashSet<String>(), ampliconBasedCalling, sample, conf, referenceResource)));
                         }
                     }
                     toPrint.put(NULL_FUTURE);
@@ -357,13 +364,14 @@ public class VarDict {
                                            final Map<String, Integer> chrs,
                                            final String ampliconBasedCalling,
                                            final String sample,
-                                           final Configuration conf) throws IOException {
+                                           final Configuration conf,
+                                           ReferenceResource referenceResource) throws IOException {
         for (List<Region> list : segs) {
             for (Region region : list) {
-                Reference reference = getREF(region, chrs, conf);
+                Reference reference = referenceResource.getREF(region, chrs, conf);
                 final Set<String> splice = new HashSet<>();
                 Tuple2<Integer, Map<Integer, Vars>> tpl = toVars(region, conf.bam.getBam1(), reference, chrs, sample,
-                        splice, ampliconBasedCalling, 0, conf);
+                        splice, ampliconBasedCalling, 0, conf, referenceResource);
                 vardict(region, tpl._2, sample, splice, conf, System.out);
             }
         }
@@ -374,7 +382,8 @@ public class VarDict {
                                         final String ampliconBasedCalling,
                                         final String sample,
                                         String samplem,
-                                        final Configuration conf) {
+                                        final Configuration conf,
+                                        ReferenceResource referenceResource) {
         final ExecutorService executor = Executors.newFixedThreadPool(conf.threads);
         final BlockingQueue<Future<OutputStream>> toSamdict = new LinkedBlockingQueue<>(10);
 
@@ -386,11 +395,11 @@ public class VarDict {
                     for (List<Region> list : segs) {
                         for (Region region : list) {
                             final Set<String> splice = new ConcurrentHashSet<>();
-                            Reference reference = getREF(region, chrs, conf);
+                            Reference reference = referenceResource.getREF(region, chrs, conf);
                             Future<Tuple2<Integer, Map<Integer, Vars>>> f1 = executor.submit(new ToVarsWorker(region,
-                                    conf.bam.getBam1(), chrs, sample, splice, ampliconBasedCalling, reference, conf));
+                                    conf.bam.getBam1(), chrs, sample, splice, ampliconBasedCalling, reference, conf, referenceResource));
                             Future<OutputStream> f2 = executor.submit(new SomdictWorker(region,
-                                    conf.bam.getBam2(), chrs, splice, ampliconBasedCalling, reference, conf, f1, sample));
+                                    conf.bam.getBam2(), chrs, splice, ampliconBasedCalling, reference, conf, f1, sample, referenceResource));
                             toSamdict.put(f2);
                         }
                     }
@@ -420,16 +429,17 @@ public class VarDict {
                                            final String ampliconBasedCalling,
                                            final String sample,
                                            String samplem,
-                                           final Configuration conf) throws IOException {
+                                           final Configuration conf,
+                                           ReferenceResource referenceResource) throws IOException {
         for (List<Region> list : segs) {
             for (Region region : list) {
                 final Set<String> splice = new ConcurrentHashSet<>();
-                Reference reference = getREF(region, chrs, conf);
+                Reference reference = referenceResource.getREF(region, chrs, conf);
                 Tuple2<Integer, Map<Integer, Vars>> t1 = toVars(region, conf.bam.getBam1(), reference, chrs, sample,
-                        splice, ampliconBasedCalling, 0, conf);
+                        splice, ampliconBasedCalling, 0, conf, referenceResource);
                 Tuple2<Integer, Map<Integer, Vars>> t2 = toVars(region, conf.bam.getBam2(), reference, chrs, sample,
-                        splice, ampliconBasedCalling, t1._1, conf);
-                somdict(region, t1._2, t2._2, sample, chrs, splice, ampliconBasedCalling, Math.max(t1._1, t2._1), conf, System.out);
+                        splice, ampliconBasedCalling, t1._1, conf, referenceResource);
+                somdict(region, t1._2, t2._2, sample, chrs, splice, ampliconBasedCalling, Math.max(t1._1, t2._1), conf, System.out, referenceResource);
             }
         }
     }
@@ -516,7 +526,7 @@ public class VarDict {
                        String sample,
                        Map<String, Integer> chrs, Set<String> splice,
                        String ampliconBasedCalling, int rlen,
-                       Configuration conf, PrintStream out) throws IOException {
+                       Configuration conf, PrintStream out, ReferenceResource referenceResource) throws IOException {
 
         Set<Integer> ps = new HashSet<>(vars1.keySet());
         ps.addAll(vars2.keySet());
@@ -631,7 +641,7 @@ public class VarDict {
                                 v2.varn.put(nt, v2nt); // Ensure it's initialized before passing to combineAnalysis
                                 if (vref.cov < conf.minr + 3 && !nt.contains("<")) {
                                     Tuple2<Integer, String> tpl = combineAnalysis(vref, v2nt, segs.chr, p, nt, chrs, sample,
-                                            splice, ampliconBasedCalling, rlen, conf);
+                                            splice, ampliconBasedCalling, rlen, conf, referenceResource);
                                     rlen = tpl._1;
                                     String newtype = tpl._2;
                                     if ("FALSE".equals(newtype)) {
@@ -727,7 +737,7 @@ public class VarDict {
                         if (v2.varn.get(nt).cov < conf.minr + 3 && !nt.contains("<")
                                 && (nt.length() > 10 || mm.find())) {
                             Tuple2<Integer, String> tpl = combineAnalysis(v2.varn.get(nt), v1nt, segs.chr, p, nt,
-                                    chrs, sample, splice, ampliconBasedCalling, rlen, conf);
+                                    chrs, sample, splice, ampliconBasedCalling, rlen, conf, referenceResource);
                             rlen = tpl._1;
                             newtype = tpl._2;
                             if ("FALSE".equals(newtype)) {
@@ -787,7 +797,7 @@ public class VarDict {
                                                    Map<String, Integer> chrs,
                                                    String sample, Set<String> splice,
                                                    String ampliconBasedCalling, int rlen,
-                                                   Configuration conf) throws IOException {
+                                                   Configuration conf, ReferenceResource referenceResource) throws IOException {
         if (conf.y) {
             System.err.printf("Start Combine %s %s\n", p, nt);
         }
@@ -797,9 +807,9 @@ public class VarDict {
         }
 
         Region region = new Region(chr, var1.sp - rlen, var1.ep + rlen, "");
-        Reference reference = getREF(region, chrs, conf);
+        Reference reference = referenceResource.getREF(region, chrs, conf);
         Tuple2<Integer, Map<Integer, Vars>> tpl = toVars(region, conf.bam.getBam1() + ":" + conf.bam.getBam2(),
-                reference, chrs, sample, splice, ampliconBasedCalling, rlen, conf);
+                reference, chrs, sample, splice, ampliconBasedCalling, rlen, conf, referenceResource);
         rlen = tpl._1;
         Map<Integer, Vars> vars = tpl._2;
         Variant vref = getVarMaybe(vars, p, varn, nt);
@@ -951,9 +961,10 @@ public class VarDict {
         final String ampliconBasedCalling;
         final Configuration conf;
         Reference reference;
+        ReferenceResource referenceResource;
 
         public ToVarsWorker(Region region, String bam, Map<String, Integer> chrs, String sample, Set<String> splice,
-                            String ampliconBasedCalling, Reference reference, Configuration conf) {
+                            String ampliconBasedCalling, Reference reference, Configuration conf, ReferenceResource referenceResource) {
             super();
             this.region = region;
             this.bam = bam;
@@ -963,14 +974,15 @@ public class VarDict {
             this.ampliconBasedCalling = ampliconBasedCalling;
             this.conf = conf;
             this.reference = reference;
+            this.referenceResource = referenceResource;
         }
 
         @Override
         public Tuple2<Integer, Map<Integer, Vars>> call() throws Exception {
             if (reference == null) {
-                reference = getREF(region, chrs, conf);
+                reference = referenceResource.getREF(region, chrs, conf);
             }
-            return toVars(region, bam, reference, chrs, sample, splice, ampliconBasedCalling, 0, conf);
+            return toVars(region, bam, reference, chrs, sample, splice, ampliconBasedCalling, 0, conf, referenceResource);
         }
     }
 
@@ -979,14 +991,16 @@ public class VarDict {
         final Future<Tuple2<Integer, Map<Integer, Vars>>> first;
         final ToVarsWorker second;
         final String sample;
+        ReferenceResource referenceResource;
 
         public SomdictWorker(Region region, String bam, Map<String, Integer> chrs, Set<String> splice,
                              String ampliconBasedCalling, Reference reference, Configuration conf,
                 Future<Tuple2<Integer, Map<Integer, Vars>>> first,
-                String sample) {
+                String sample, ReferenceResource referenceResource) {
             this.first = first;
-            this.second = new ToVarsWorker(region, bam, chrs, sample, splice, ampliconBasedCalling, reference, conf);
+            this.second = new ToVarsWorker(region, bam, chrs, sample, splice, ampliconBasedCalling, reference, conf, referenceResource);
             this.sample = sample;
+            this.referenceResource = referenceResource;
         }
 
         @Override
@@ -996,7 +1010,7 @@ public class VarDict {
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
             PrintStream out = new PrintStream(baos);
             somdict(second.region, t1._2, t2._2, sample, second.chrs, second.splice, second.ampliconBasedCalling,
-                    Math.max(t1._1, t2._1), second.conf, out);
+                    Math.max(t1._1, t2._1), second.conf, out, referenceResource);
             out.close();
             return baos;
         }
@@ -1010,9 +1024,10 @@ public class VarDict {
         private Map<String, Integer> chrs;
         private Set<String> splice;
         private String ampliconBasedCalling;
+        private ReferenceResource referenceResource;
 
         public VardictWorker(Region region, Map<String, Integer> chrs, Set<String> splice, String ampliconBasedCalling,
-                             String sample, Configuration conf) {
+                             String sample, Configuration conf, ReferenceResource referenceResource) {
             super();
             this.region = region;
             this.chrs = chrs;
@@ -1020,13 +1035,14 @@ public class VarDict {
             this.ampliconBasedCalling = ampliconBasedCalling;
             this.sample = sample;
             this.conf = conf;
+            this.referenceResource = referenceResource;
         }
 
         @Override
         public OutputStream call() throws Exception {
-            Reference reference = getREF(region, chrs, conf);
+            Reference reference = referenceResource.getREF(region, chrs, conf);
             Tuple2<Integer, Map<Integer, Vars>> tpl = toVars(region, conf.bam.getBam1(), reference,
-                    chrs, sample, splice, ampliconBasedCalling, 0, conf);
+                    chrs, sample, splice, ampliconBasedCalling, 0, conf, referenceResource);
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
             PrintStream out = new PrintStream(baos);
             vardict(region, tpl._2, sample, splice, conf, out);
@@ -1078,7 +1094,7 @@ public class VarDict {
 
     private static void ampVardictParallel(final List<List<Region>> segs, final Map<String, Integer> chrs,
             final String ampliconBasedCalling,
-            final String bam1, final String sample, final Configuration conf) {
+            final String bam1, final String sample, final Configuration conf, ReferenceResource referenceResource) {
 
         final ExecutorService executor = Executors.newFixedThreadPool(conf.threads);
         final BlockingQueue<Future<OutputStream>> toPrint = new LinkedBlockingQueue<>(21);
@@ -1103,7 +1119,7 @@ public class VarDict {
                                 }
                                 list.add(tuple(j, region));
                             }
-                            ToVarsWorker toVars = new ToVarsWorker(region, bam1, chrs, sample, splice, ampliconBasedCalling, null, conf);
+                            ToVarsWorker toVars = new ToVarsWorker(region, bam1, chrs, sample, splice, ampliconBasedCalling, null, conf, referenceResource);
                             if (workers.size() == regions.size() - 1) {
                                 toPrint.put(executor.submit(new AmpVardictWorker(pos, rg, sample, workers, toVars)));
                             } else {
@@ -1139,7 +1155,8 @@ public class VarDict {
                                               final String ampliconBasedCalling,
                                               final String bam1,
                                               final String sample,
-                                              final Configuration conf) throws IOException {
+                                              final Configuration conf,
+                                              ReferenceResource referenceResource) throws IOException {
 
         for (List<Region> regions : segs) {
             Map<Integer, List<Tuple2<Integer, Region>>> pos = new HashMap<>();
@@ -1157,7 +1174,7 @@ public class VarDict {
                     }
                     list.add(tuple(j, region));
                 }
-                vars.add(toVars(region, bam1, getREF(region, chrs, conf), chrs, sample, splice, ampliconBasedCalling, 0, conf)._2);
+                vars.add(toVars(region, bam1, referenceResource.getREF(region, chrs, conf), chrs, sample, splice, ampliconBasedCalling, 0, conf, referenceResource)._2);
                 j++;
             }
             ampVardict(rg, vars, pos, sample, splice, conf, System.out);

--- a/src/main/java/com/astrazeneca/vardict/VarDict.java
+++ b/src/main/java/com/astrazeneca/vardict/VarDict.java
@@ -38,7 +38,6 @@ public class VarDict {
     }
     /**
      * The main method to start Vardict in any mode.
-     * @param conf prepared configuration object from arguments
      * @throws IOException if BAM file can't be read
      */
     public void start() throws IOException {
@@ -517,6 +516,7 @@ public class VarDict {
      * @param splice set of strings representing introns in splice
      * @param ampliconBasedCalling string of maximum_distance:minimum_overlap for amplicon based calling
      * @param rlen max read length
+     * @param referenceResource object for access to reference map
      * @param conf Configuration
      * @param out output stream
      * @return maximum read length
@@ -782,7 +782,7 @@ public class VarDict {
      * @param chr chromosome
      * @param p position
      * @param nt nucleotide
-     *
+     * @param referenceResource object for access to reference map
      * @param chrs map of chromosome lengths
      * @param sample sample name
      * @param splice set of strings representing introns in splice

--- a/src/main/java/com/astrazeneca/vardict/modules/SAMFileParser.java
+++ b/src/main/java/com/astrazeneca/vardict/modules/SAMFileParser.java
@@ -67,6 +67,7 @@ public class SAMFileParser {
      * @param sclip3 map of soft clips 3' on positions
      * @param sclip5 map of soft clips 5' on positions
      * @param svflag true if BAM file is re-parsed due to structural variants analysis on extended region of interest
+     * @param referenceResource object for access to reference map
      * @return Tuple of (noninsertion variant  structure, insertion variant structure, coverage, maxmimum read length)
      * @throws IOException if BAM file can't be read
      */

--- a/src/main/java/com/astrazeneca/vardict/modules/SAMFileParser.java
+++ b/src/main/java/com/astrazeneca/vardict/modules/SAMFileParser.java
@@ -1,6 +1,7 @@
 package com.astrazeneca.vardict.modules;
 
 import com.astrazeneca.vardict.Configuration;
+import com.astrazeneca.vardict.ReferenceResource;
 import com.astrazeneca.vardict.collection.Tuple;
 import com.astrazeneca.vardict.collection.VariationMap;
 import com.astrazeneca.vardict.data.*;
@@ -75,7 +76,7 @@ public class SAMFileParser {
                                                              Map<String, Integer> chrs,
                                                              String sample, Set<String> splice,
                                                              String ampliconBasedCalling, int rlen,
-                                                             Reference reference, Configuration conf,
+                                                             Reference reference, ReferenceResource referenceResource, Configuration conf,
                                                              Map<Integer, VariationMap<String, Variation>> hash,
                                                              Map<Integer, VariationMap<String, Variation>> iHash,
                                                              Map<Integer, Integer> cov,
@@ -1199,14 +1200,14 @@ public class SAMFileParser {
         adjMNP(hash, mnp, cov, ref, sclip3, sclip5, conf);
 
         if (conf.performLocalRealignment) {
-            VariationRealigner.realignIndels(region, chrs, rlen, reference, conf, bam, hash, iHash, cov, sclip3,
+            VariationRealigner.realignIndels(region, chrs, rlen, reference, referenceResource, conf, bam, hash, iHash, cov, sclip3,
                     sclip5, sample, splice, ampliconBasedCalling, ins, dels5,
                     svStructures);
         }
 
         if(!conf.disableSV) {
             findAllSVs(region, bam, chrs, sample, splice, ampliconBasedCalling, rlen,
-                    reference, conf, hash, iHash, cov, sclip3, sclip5, svStructures);
+                    reference, conf, hash, iHash, cov, sclip3, sclip5, svStructures, referenceResource);
         }
         if (conf.y) {
             outputClipping(sclip5, sclip3, conf);

--- a/src/main/java/com/astrazeneca/vardict/modules/StructuralVariantsProcessor.java
+++ b/src/main/java/com/astrazeneca/vardict/modules/StructuralVariantsProcessor.java
@@ -367,6 +367,7 @@ public class StructuralVariantsProcessor {
      * @param sclip5 map of soft clips 5' on positions
      * @param svStructures Contains all structural variants ends for deletions, duplications, inversions, insertions
     and structures for structural variant analysis
+     * @param referenceResource object for access to reference map
      * @throws IOException if BAM file can't be read
      */
     static void findAllSVs(Region region, String bam, Map<String, Integer> chrs, String sample,
@@ -1102,6 +1103,7 @@ public class StructuralVariantsProcessor {
      * @param svrinv3 list of INV SVs in reverse direction of 3'
      * @param svrinv5 list of INV SVs in reverse direction of 5'
      * @param conf Configuration
+     * @param referenceResource object for access to reference map
      * @param RLEN max read length
      * @param chrs map of chromosome lengths
      */
@@ -1308,6 +1310,7 @@ public class StructuralVariantsProcessor {
      * @param svrdup list of DUP SVs in discordant pairs in reverse direction
      * @param conf Configuration
      * @param RLEN max read length
+     * @param referenceResource object for access to reference map
      * @param chrs map of chromosome lengths
      * @throws IOException if BAM file can't be read
      */
@@ -1824,6 +1827,7 @@ public class StructuralVariantsProcessor {
      * @param svfdel list of DEL SVs in discordant pairs in forward direction
      * @param svrdel list of DEL SVs in discordant pairs in reverse direction
      * @param conf Configuration
+     * @param referenceResource object for access to reference map
      * @param rlen max read length
      * @param chrs map of chromosome lengths
      */
@@ -1975,6 +1979,7 @@ public class StructuralVariantsProcessor {
      * @param rlen max read length
      * @param chrs map of chromosome lengths
      * @param sample sample name
+     * @param referenceResource object for access to reference map
      * @param splice set of strings representing spliced regions
      * @param ampliconBasedCalling string of maximum_distance:minimum_overlap for amplicon based calling
      * @throws IOException if BAM file can't be read
@@ -2333,6 +2338,7 @@ public class StructuralVariantsProcessor {
      * @param svrinv5 list of INV SVs in reverse direction in 5'
      * @param rlen max read length
      * @param chrs map of chromosome lengths
+     * @param referenceResource object for access to reference map
      * @param sample sample name
      * @param splice set of strings representing spliced regions
      * @param ampliconBasedCalling string of maximum_distance:minimum_overlap for amplicon based calling
@@ -2380,6 +2386,7 @@ public class StructuralVariantsProcessor {
      * @param side 3 or 5 end
      * @param rlen max read length
      * @param chrs map of chromosome lengths
+     * @param referenceResource object for access to reference map
      * @param sample sample name
      * @param splice set of strings representing spliced regions
      * @param ampliconBasedCalling string of maximum_distance:minimum_overlap for amplicon based calling

--- a/src/main/java/com/astrazeneca/vardict/modules/StructuralVariantsProcessor.java
+++ b/src/main/java/com/astrazeneca/vardict/modules/StructuralVariantsProcessor.java
@@ -20,7 +20,6 @@ import java.util.*;
 
 import static com.astrazeneca.vardict.collection.VariationMap.getSV;
 import static com.astrazeneca.vardict.data.Patterns.*;
-import static com.astrazeneca.vardict.ReferenceResource.getREF;
 import static com.astrazeneca.vardict.ReferenceResource.isLoaded;
 import static com.astrazeneca.vardict.collection.VariationMap.SV;
 import static com.astrazeneca.vardict.modules.SAMFileParser.getMrnm;
@@ -375,16 +374,16 @@ public class StructuralVariantsProcessor {
                                   Configuration conf, Map<Integer, VariationMap<String, Variation>> hash,
                                   Map<Integer, VariationMap<String, Variation>> iHash, Map<Integer, Integer> cov,
                                   Map<Integer, Sclip> sclip3, Map<Integer, Sclip> sclip5,
-                                  SVStructures svStructures) throws IOException {
+                                  SVStructures svStructures, ReferenceResource referenceResource) throws IOException {
         if (conf.y) {
             System.err.println("Start Structural Variants: DEL\n");
         }
-        findDEL(conf, hash, iHash, cov, sclip5, sclip3, reference, region, bam, svStructures.svfdel,
+        findDEL(conf, hash, iHash, cov, sclip5, sclip3, reference, referenceResource, region, bam, svStructures.svfdel,
                 svStructures.svrdel, rlen, chrs, sample, splice, ampliconBasedCalling);
         if (conf.y) {
             System.err.println("Start Structural Variants: INV\n");
         }
-        findINV(conf, hash, iHash, cov, sclip5, sclip3, reference, region, bam, svStructures.svfinv3,
+        findINV(conf, hash, iHash, cov, sclip5, sclip3, reference, referenceResource, region, bam, svStructures.svfinv3,
                 svStructures.svrinv3, svStructures.svfinv5, svStructures.svrinv5,
                 rlen, chrs, sample, splice, ampliconBasedCalling);
         if (conf.y) {
@@ -394,17 +393,17 @@ public class StructuralVariantsProcessor {
         if (conf.y) {
             System.err.println("Start Structural Variants: DEL discordant pairs only\n");
         }
-        findDELdisc(conf, hash, cov, sclip5, sclip3, reference, region, svStructures.svfdel,
+        findDELdisc(conf, hash, cov, sclip5, sclip3, reference, referenceResource, region, svStructures.svfdel,
                 svStructures.svrdel, splice, rlen, chrs) ;
         if (conf.y) {
             System.err.println("Start Structural Variants: INV discordant pairs only\n");
         }
-        findINVdisc(hash, cov, sclip5, sclip3, reference, region, svStructures.svfinv3, svStructures.svrinv3,
+        findINVdisc(hash, cov, sclip5, sclip3, reference, referenceResource, region, svStructures.svfinv3, svStructures.svrinv3,
                 svStructures.svfinv5, svStructures.svrinv5, conf, rlen, chrs);
         if (conf.y) {
             System.err.println("Start Structural Variants: DUP discordant pairs only\n");
         }
-        findDUPdisc(hash, iHash, cov, sclip5, sclip3, reference, region, bam, sample, splice,
+        findDUPdisc(hash, iHash, cov, sclip5, sclip3, reference, referenceResource, region, bam, sample, splice,
                 ampliconBasedCalling, svStructures.svfdup, svStructures.svrdup, conf, rlen, chrs);
     }
 
@@ -1110,7 +1109,7 @@ public class StructuralVariantsProcessor {
                              Map<Integer, Integer> cov,
                              Map<Integer, Sclip> sclip5,
                              Map<Integer, Sclip> sclip3,
-                             Reference reference, Region region,
+                             Reference reference, ReferenceResource referenceResource, Region region,
                              List<Sclip> svfinv3,
                              List<Sclip> svrinv3,
                              List<Sclip> svfinv5,
@@ -1157,7 +1156,7 @@ public class StructuralVariantsProcessor {
                     int pe = abs((me+rms)/2);
                     if (!ref.containsKey(pe)) {
                         Region modifiedRegion = Region.newModifiedRegion(region, pe - 150, pe + 150);
-                        getREF(modifiedRegion, chrs, conf, 300, reference);
+                        referenceResource.getREF(modifiedRegion, chrs, conf, 300, reference);
                     }
                     int len = pe - bp + 1;
 
@@ -1240,7 +1239,7 @@ public class StructuralVariantsProcessor {
                     int bp = abs((me + rms)/2);
                     if (!ref.containsKey(bp)) {
                         Region modifiedRegion = Region.newModifiedRegion(region, bp - 150, bp + 150);
-                        getREF(modifiedRegion, chrs, conf, 300, reference);
+                        referenceResource.getREF(modifiedRegion, chrs, conf, 300, reference);
                     }
                     int len = pe - bp + 1;
                     String ins5 = SequenceUtil.reverseComplement(joinRef(ref, bp, bp + Configuration.SVFLANK - 1));
@@ -1317,7 +1316,7 @@ public class StructuralVariantsProcessor {
                              Map<Integer, Integer> cov,
                              Map<Integer, Sclip> sclip5,
                              Map<Integer, Sclip> sclip3,
-                             Reference reference,
+                             Reference reference, ReferenceResource referenceResource,
                              Region region,
                              String bam,
                              String sample,
@@ -1354,10 +1353,10 @@ public class StructuralVariantsProcessor {
 
             if(!ReferenceResource.isLoaded(region.chr, ms, me, reference)) {
                 if (!ref.containsKey(bp)) {
-                    getREF(Region.newModifiedRegion(region, bp - 150, bp + 150), chrs, conf, 300, reference);
+                    referenceResource.getREF(Region.newModifiedRegion(region, bp - 150, bp + 150), chrs, conf, 300, reference);
                 }
                 parseSAM(Region.newModifiedRegion(region, ms - 200, me + 200), bam, chrs, sample, splice,
-                        ampliconBasedCalling, RLEN, reference, conf, hash,
+                        ampliconBasedCalling, RLEN, reference, referenceResource, conf, hash,
                         iHash, cov, sclip3, sclip5, true);
             }
 
@@ -1491,10 +1490,10 @@ public class StructuralVariantsProcessor {
             int tpe = pe;
             if (!ReferenceResource.isLoaded(region.chr, ms, me, reference) ) {
                 if (!ref.containsKey(pe)) {
-                    getREF(Region.newModifiedRegion(region, pe - 150, pe + 150), chrs, conf, 300, reference);
+                    referenceResource.getREF(Region.newModifiedRegion(region, pe - 150, pe + 150), chrs, conf, 300, reference);
                 }
                 parseSAM(Region.newModifiedRegion(region, ms - 200, me + 200), bam, chrs, sample, splice,
-                        ampliconBasedCalling, RLEN, reference, conf, hash,
+                        ampliconBasedCalling, RLEN, reference, referenceResource, conf, hash,
                         iHash, cov, sclip3, sclip5, true);
             }
             int cntf = cnt;
@@ -1833,7 +1832,7 @@ public class StructuralVariantsProcessor {
                             Map<Integer, Integer> cov,
                             Map<Integer, Sclip> sclip5,
                             Map<Integer, Sclip> sclip3,
-                            Reference REF,
+                            Reference REF, ReferenceResource referenceResource,
                             Region region,
                             List<Sclip> svfdel,
                             List<Sclip> svrdel,
@@ -1955,7 +1954,7 @@ public class StructuralVariantsProcessor {
                 cov.put(bp, cov.get(del.start));
             }
             del.used = true;
-            getREF(Region.newModifiedRegion(region, del.mstart - 100, del.mend + 100), chrs, conf, 200, REF);
+            referenceResource.getREF(Region.newModifiedRegion(region, del.mstart - 100, del.mend + 100), chrs, conf, 200, REF);
             markSV(del.mend, del.start, Arrays.asList(svfdel), rlen, conf);
         }
     }
@@ -1986,7 +1985,7 @@ public class StructuralVariantsProcessor {
                         Map<Integer, Integer> cov,
                         Map<Integer, Sclip> sclip5,
                         Map<Integer, Sclip> sclip3,
-                        Reference reference,
+                        Reference reference, ReferenceResource referenceResource,
                         Region region,
                         String bams,
                         List<Sclip> svfdel,
@@ -2023,9 +2022,9 @@ public class StructuralVariantsProcessor {
                     continue; // next unless( $seq && length($seq) >= $SEED2 );
                 }
                 if (!isLoaded(region.chr, del.mstart, del.mend, reference)) {
-                    getREF(Region.newModifiedRegion(region, del.mstart, del.mend), chrs, conf, 300, reference);
+                    referenceResource.getREF(Region.newModifiedRegion(region, del.mstart, del.mend), chrs, conf, 300, reference);
                     parseSAM(Region.newModifiedRegion(region, del.mstart - 200, del.mend + 200),
-                            bams, chrs, sample, splice, ampliconBasedCalling, rlen, reference, conf, hash,
+                            bams, chrs, sample, splice, ampliconBasedCalling, rlen, reference, referenceResource, conf, hash,
                             iHash, cov, sclip3, sclip5, true);
                 }
                 Tuple.Tuple2<Integer, String> match = findMatch(conf, seq, reference, softp, 1);
@@ -2085,7 +2084,7 @@ public class StructuralVariantsProcessor {
                 }
             } else { // Look within a read length
                 if(!isLoaded(region.chr, del.mstart, del.mend, reference)) {
-                    getREF(Region.newModifiedRegion(region, del.mstart, del.mend), chrs, conf, 300, reference);
+                    referenceResource.getREF(Region.newModifiedRegion(region, del.mstart, del.mend), chrs, conf, 300, reference);
                 }
                 if (conf.y) {
                     System.err.printf("%n%nWorking DEL 5' no softp mate cluster cnt: %d%n", del.cnt);
@@ -2186,9 +2185,9 @@ public class StructuralVariantsProcessor {
                     continue;
                 }
                 if (!isLoaded(region.chr, del.mstart, del.mend, reference)) {
-                    getREF(Region.newModifiedRegion(region, del.mstart, del.mend), chrs, conf, 300, reference);
+                    referenceResource.getREF(Region.newModifiedRegion(region, del.mstart, del.mend), chrs, conf, 300, reference);
                     parseSAM(Region.newModifiedRegion(region, del.mstart - 200, del.mend + 200),
-                            bams, chrs, sample, splice, ampliconBasedCalling, rlen, reference, conf,
+                            bams, chrs, sample, splice, ampliconBasedCalling, rlen, reference, referenceResource, conf,
                             hash, iHash, cov, sclip3, sclip5, true);
                 }
                 Tuple.Tuple2<Integer, String> match = findMatch(conf, seq, reference, softp, -1);// my ($bp, $EXTRA) = findMatch($seq, $reference, $softp, -1);
@@ -2243,7 +2242,7 @@ public class StructuralVariantsProcessor {
                     System.err.printf("%n%nWorking DEL 3' no softp mate cluster %s %d %d cnt: %d%n", region.chr, del.mstart, del.mend, del.cnt);
                 }
                 if (!isLoaded(region.chr, del.mstart, del.mend, reference)) {
-                    getREF(Region.newModifiedRegion(region, del.mstart, del.mend), chrs, conf, 300, reference);
+                    referenceResource.getREF(Region.newModifiedRegion(region, del.mstart, del.mend), chrs, conf, 300, reference);
                 }
                 for (Map.Entry<Integer, Sclip> entry : sclip5.entrySet()) {
                     int i = entry.getKey();
@@ -2345,7 +2344,7 @@ public class StructuralVariantsProcessor {
                         Map<Integer, Integer> cov,
                         Map<Integer, Sclip> sclip5,
                         Map<Integer, Sclip> sclip3,
-                        Reference REF,
+                        Reference REF, ReferenceResource referenceResource,
                         Region region,
                         String bams,
                         Iterable<Sclip> svfinv3,
@@ -2357,10 +2356,10 @@ public class StructuralVariantsProcessor {
                         String sample,
                         Set<String> splice,
                         String ampliconBasedCalling) throws IOException {
-        findINVsub(conf, hash, iHash, cov, sclip5, sclip3, REF, region, bams, svfinv5, 1 , Side._5, rlen, chrs, sample, splice, ampliconBasedCalling);
-        findINVsub(conf, hash, iHash, cov, sclip5, sclip3, REF, region, bams, svrinv5, -1 , Side._5, rlen, chrs, sample, splice, ampliconBasedCalling);
-        findINVsub(conf, hash, iHash, cov, sclip5, sclip3, REF, region, bams, svfinv3, 1 , Side._3, rlen, chrs, sample, splice, ampliconBasedCalling);
-        findINVsub(conf, hash, iHash, cov, sclip5, sclip3, REF, region, bams, svrinv3, -1 , Side._3, rlen, chrs, sample, splice, ampliconBasedCalling);
+        findINVsub(conf, hash, iHash, cov, sclip5, sclip3, REF, referenceResource, region, bams, svfinv5, 1 , Side._5, rlen, chrs, sample, splice, ampliconBasedCalling);
+        findINVsub(conf, hash, iHash, cov, sclip5, sclip3, REF, referenceResource, region, bams, svrinv5, -1 , Side._5, rlen, chrs, sample, splice, ampliconBasedCalling);
+        findINVsub(conf, hash, iHash, cov, sclip5, sclip3, REF, referenceResource, region, bams, svfinv3, 1 , Side._3, rlen, chrs, sample, splice, ampliconBasedCalling);
+        findINVsub(conf, hash, iHash, cov, sclip5, sclip3, REF, referenceResource, region, bams, svrinv3, -1 , Side._3, rlen, chrs, sample, splice, ampliconBasedCalling);
     }
 
     /**
@@ -2393,7 +2392,7 @@ public class StructuralVariantsProcessor {
                                 Map<Integer, Integer> cov,
                                 Map<Integer, Sclip> sclip5,
                                 Map<Integer, Sclip> sclip3,
-                                Reference reference,
+                                Reference reference, ReferenceResource referenceResource,
                                 Region region,
                                 String bams,
                                 Iterable<Sclip> svref,
@@ -2420,9 +2419,9 @@ public class StructuralVariantsProcessor {
             Map<Integer, Sclip> sclip = dir == 1 ? sclip3 : sclip5;
             if (conf.y) System.err.printf("%n%nWorking INV %d %d %s pair_cnt: %d%n", softp, dir, side, inv.cnt);
             if (!isLoaded(region.chr, inv.mstart, inv.mend, reference)) {
-                getREF(Region.newModifiedRegion(region, inv.mstart, inv.mend), chrs, conf, 500, reference);
+                referenceResource.getREF(Region.newModifiedRegion(region, inv.mstart, inv.mend), chrs, conf, 500, reference);
                 parseSAM(Region.newModifiedRegion(region, inv.mstart - 200, inv.mend + 200),
-                        bams, chrs, sample, splice, ampliconBasedCalling, rlen, reference, conf, hash,
+                        bams, chrs, sample, splice, ampliconBasedCalling, rlen, reference, referenceResource, conf, hash,
                         iHash, cov, sclip3, sclip5, true);
             }
             int bp = 0;

--- a/src/main/java/com/astrazeneca/vardict/modules/ToVarsBuilder.java
+++ b/src/main/java/com/astrazeneca/vardict/modules/ToVarsBuilder.java
@@ -1,6 +1,7 @@
 package com.astrazeneca.vardict.modules;
 
 import com.astrazeneca.vardict.Configuration;
+import com.astrazeneca.vardict.ReferenceResource;
 import com.astrazeneca.vardict.Utils;
 import com.astrazeneca.vardict.collection.Tuple;
 import com.astrazeneca.vardict.collection.VariationMap;
@@ -53,7 +54,7 @@ public class ToVarsBuilder {
                                                             Set<String> SPLICE,
                                                             String ampliconBasedCalling,
                                                             int Rlen,
-                                                            Configuration conf) throws IOException {
+                                                            Configuration conf, ReferenceResource referenceResource) throws IOException {
         Map<Integer, VariationMap<String, Variation>> hash = new HashMap<>(); // variations map
         Map<Integer, VariationMap<String, Variation>> iHash = new HashMap<>(); // insertions map
         Map<Integer, Integer> cov = new HashMap<>();
@@ -64,7 +65,7 @@ public class ToVarsBuilder {
 
         Tuple.Tuple5<Map<Integer, VariationMap<String, Variation>>, Map<Integer, VariationMap<String, Variation>>,
                 Map<Integer, Integer>, Integer, Double> parseTpl =
-                parseSAM(region, bam, chrs, sample, SPLICE, ampliconBasedCalling, Rlen, reference,
+                parseSAM(region, bam, chrs, sample, SPLICE, ampliconBasedCalling, Rlen, reference, referenceResource,
                         conf, hash,
                         iHash, cov, sclip3, sclip5, svflag);
 

--- a/src/main/java/com/astrazeneca/vardict/modules/ToVarsBuilder.java
+++ b/src/main/java/com/astrazeneca/vardict/modules/ToVarsBuilder.java
@@ -42,6 +42,7 @@ public class ToVarsBuilder {
      * @param SPLICE set of strings representing spliced regions
      * @param ampliconBasedCalling string of maximum_distance:minimum_overlap for amplicon based calling
      * @param Rlen maximum read length
+     * @param referenceResource object for access to reference map
      * @param conf VarDict configuration
      * @return Tuple of (maximum read length, variant structure)
      * @throws IOException if BAM file can't be read

--- a/src/main/java/com/astrazeneca/vardict/modules/VariationRealigner.java
+++ b/src/main/java/com/astrazeneca/vardict/modules/VariationRealigner.java
@@ -676,6 +676,7 @@ public class VariationRealigner {
      * @param bam BAM file list
      * @param svfdel list of DEL SVs in forward strand
      * @param svrdel list of DEL SVs in reverse strand
+     * @param referenceResource object for access to reference map
      * @param conf configuration
      * @throws IOException if BAM file can't be read
      */
@@ -1094,6 +1095,7 @@ public class VariationRealigner {
      * @param bam BAM file list
      * @param svfdup list of DUP SVs in forward strand
      * @param svrdup list of DUP SVs in reverse strand
+     * @param referenceResource object for access to reference map
      * @param conf configuration
      * @throws IOException if BAM file can't be read
      */

--- a/src/main/java/com/astrazeneca/vardict/modules/VariationRealigner.java
+++ b/src/main/java/com/astrazeneca/vardict/modules/VariationRealigner.java
@@ -1,6 +1,7 @@
 package com.astrazeneca.vardict.modules;
 
 import com.astrazeneca.vardict.Configuration;
+import com.astrazeneca.vardict.ReferenceResource;
 import com.astrazeneca.vardict.data.Region;
 import com.astrazeneca.vardict.Utils;
 import com.astrazeneca.vardict.collection.Tuple;
@@ -21,7 +22,6 @@ import static com.astrazeneca.vardict.collection.VariationMap.removeSV;
 import static com.astrazeneca.vardict.data.Patterns.*;
 import static com.astrazeneca.vardict.modules.CigarUtils.getAlignedLength;
 import static com.astrazeneca.vardict.modules.SAMFileParser.parseSAM;
-import static com.astrazeneca.vardict.ReferenceResource.getREF;
 import static com.astrazeneca.vardict.ReferenceResource.isLoaded;
 import static com.astrazeneca.vardict.modules.StructuralVariantsProcessor.findMatch;
 import static com.astrazeneca.vardict.modules.StructuralVariantsProcessor.markDUPSV;
@@ -54,7 +54,7 @@ public class VariationRealigner {
     public static void realignIndels(Region region,
                                      Map<String, Integer> chrs,
                                      int rlen,
-                                     Reference reference,
+                                     Reference reference, ReferenceResource referenceResource,
                                      Configuration conf,
                                      String bam,
                                      Map<Integer, VariationMap<String, Variation>> hash,
@@ -77,14 +77,14 @@ public class VariationRealigner {
         if (conf.y)
             System.err.println("Start Realignlgdel");
         realignlgdel(hash, cov, sclip5, sclip3, sample, splice, ampliconBasedCalling,
-                reference, region, chrs, iHash, rlen, bam, svStructures.svfdel, svStructures.svrdel, conf);
+                reference, referenceResource, region, chrs, iHash, rlen, bam, svStructures.svfdel, svStructures.svrdel, conf);
         if (conf.y)
             System.err.println("Start Realignlgins30");
         realignlgins30(hash, iHash, cov, sclip5, sclip3, reference, region, chrs, rlen, bam, conf);
         if (conf.y)
             System.err.println("Start Realignlgins");
         realignlgins(hash, iHash, cov, sclip5, sclip3, sample, splice, ampliconBasedCalling,
-                reference, region, chrs, rlen, bam, svStructures.svfdup, svStructures.svrdup, conf);
+                reference, referenceResource, region, chrs, rlen, bam, svStructures.svfdup, svStructures.svrdup, conf);
     }
 
     /**
@@ -685,7 +685,7 @@ public class VariationRealigner {
                              Map<Integer, Sclip> sclip3,
                              String sample, Set<String> splice,
                              String ampliconBasedCalling,
-                             Reference reference,
+                             Reference reference, ReferenceResource referenceResource,
                              Region region,
                              Map<String, Integer> chrs,
                              Map<Integer, VariationMap<String, Variation>> iHash,
@@ -776,10 +776,10 @@ public class VariationRealigner {
                     }
                     Region modifiedRegion = Region.newModifiedRegion(region, tts, tte);
                     if(!isLoaded(chr, tts, tte, reference)) {
-                        getREF(modifiedRegion, chrs, conf, rlen, reference);
+                        referenceResource.getREF(modifiedRegion, chrs, conf, rlen, reference);
                     }
                     parseSAM(modifiedRegion,  bam, chrs, sample, splice, ampliconBasedCalling,
-                            rlen, reference, conf, hash, iHash, cov, sclip3, sclip5, true);
+                            rlen, reference, referenceResource, conf, hash, iHash, cov, sclip3, sclip5, true);
                 }
             }
             int dellen = p - bp;
@@ -984,10 +984,10 @@ public class VariationRealigner {
                     }
                     Region modifiedRegion = Region.newModifiedRegion(region, tts, tte);
                     if (!isLoaded(chr, tts, tte, reference)) {
-                        getREF(modifiedRegion, chrs, conf, rlen, reference);
+                        referenceResource.getREF(modifiedRegion, chrs, conf, rlen, reference);
                     }
                     parseSAM(modifiedRegion, bam, chrs, sample, splice, ampliconBasedCalling,
-                            rlen, reference, conf, hash, iHash, cov, sclip3, sclip5, true);
+                            rlen, reference, referenceResource, conf, hash, iHash, cov, sclip3, sclip5, true);
                 }
             }
 
@@ -1104,7 +1104,7 @@ public class VariationRealigner {
                              Map<Integer, Sclip> sclip3,
                              String sample, Set<String> splice,
                              String ampliconBasedCalling,
-                             Reference reference,
+                             Reference reference, ReferenceResource referenceResource,
                              Region region,
                              Map<String, Integer> chrs,
                              int rlen,
@@ -1177,10 +1177,10 @@ public class VariationRealigner {
                     }
                     Region modifiedRegion = Region.newModifiedRegion(region, tts, tte);
                     if(!isLoaded(chr, tts, tte, reference)) {
-                        getREF(modifiedRegion, chrs, conf, rlen, reference);
+                        referenceResource.getREF(modifiedRegion, chrs, conf, rlen, reference);
                     }
                     parseSAM(modifiedRegion,  bam, chrs, sample, splice, ampliconBasedCalling,
-                            rlen, reference, conf, hash, iHash, cov, sclip3, sclip5, true);
+                            rlen, reference, referenceResource, conf, hash, iHash, cov, sclip3, sclip5, true);
                 }
                 if (bi - p > conf.SVMINLEN + 2 * Configuration.SVFLANK ) {
                     ins = joinRef(ref, p, p + Configuration.SVFLANK - 1);
@@ -1336,10 +1336,10 @@ public class VariationRealigner {
                     }
                     Region modifiedRegion = Region.newModifiedRegion(region, tts, tte);
                     if(!isLoaded(chr, tts, tte, reference)) {
-                        getREF(modifiedRegion, chrs, conf, rlen, reference);
+                        referenceResource.getREF(modifiedRegion, chrs, conf, rlen, reference);
                     }
                     parseSAM(modifiedRegion,  bam, chrs, sample, splice, ampliconBasedCalling,
-                            rlen, reference, conf, hash, iHash, cov, sclip3, sclip5, true);
+                            rlen, reference, referenceResource, conf, hash, iHash, cov, sclip3, sclip5, true);
                 }
                 int shift5 = 0;
                 while (ref.containsKey(p - 1) && ref.containsKey(bi - 1)

--- a/src/main/java/com/astrazeneca/vardict/variations/Variant.java
+++ b/src/main/java/com/astrazeneca/vardict/variations/Variant.java
@@ -192,7 +192,7 @@ public class Variant {
      * there're no more than 3 reads
      * @param goodq quality threshold
      * @param lofreq The minimum allele frequency allowed in normal for a somatic mutation
-     * @return Returns <tt>true</tt> if variance is considered noise if the quality is below <code>goodq</code>
+     * @return Returns true if variance is considered noise if the quality is below <code>goodq</code>
      * and there're no more than 3 reads in coverage
      */
     public boolean isNoise(double goodq,

--- a/src/main/java/com/astrazeneca/vardict/variations/VariationUtils.java
+++ b/src/main/java/com/astrazeneca/vardict/variations/VariationUtils.java
@@ -346,13 +346,13 @@ public class VariationUtils {
     }
 
     /**
-     * Returns <tt>true</tt> whether a variant meet specified criteria
+     * Returns true whether a variant meet specified criteria
      * @param vref variant
      * @param referenceVar reference variant    $rref
      * @param type Type of variant
      * @param splice set of strings representing introns in splice
      * @param conf Configuration (contains preferences for min, freq, filter and etc)
-     * @return <tt>true</tt> if variant meet specified criteria
+     * @return true if variant meet specified criteria
      */
     public static boolean isGoodVar(Variant vref, Variant referenceVar, String type,
                                     Set<String> splice,


### PR DESCRIPTION
### Description
In 1.5.7 version tests will fall on Java 11, because PowerMock doesn't support Java 11 (and maybe won't support, because there are no releases of PowerMock since May 2018).

The changes are:
* Changed methods of ReferenceResource.class to be not static. In further refactoring Reference need to be added to Scope to avoid extra parameters in methods. Current PR is a quick solution, because Oracle stopped support of Java 10.
* Changed mock library to Mockito (now we won't use the mocking of static methods of PowerMock).
* Updated starting test for all the test cases.
* Updated version of jacoco.
* Updated Travis config: added JDK 11. 