### PR TITLE
Prevent duplicate JVM options when JAVA_OPTS is used

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ startScripts {
         unixScript.text = unixScript.text.replaceAll(/(DEFAULT_JVM_OPTS=.*)/){ all, group -> 
 """${group}
 
-if [ -n "\$${optsEnvironmentVar}" ] ; then
+if [ -n "\$${optsEnvironmentVar}" ] || [ -n "\$JAVA_OPTS" ] ; then
     DEFAULT_JVM_OPTS=''
 fi
 """


### PR DESCRIPTION
Solves https://github.com/AstraZeneca-NGS/VarDictJava/issues/4#issuecomment-453053636

Given:

```diff
/pipeline/packages/VarDictJava/build/install/VarDict/bin/VarDict
177c177
< exec "$JAVACMD" "$@"
---
> echo "exec $JAVACMD $@"
```

We get no duplicated options with `DEFAULT_JVM_OPTS`:

```bash
❯ JAVA_OPTS=-Xmx10g build/install/VarDict/bin/VarDict
exec java -Xmx10g -classpath /Users/cvalentine/repositories/VarDictJava/build/install/VarDict/lib/VarDict-1.5.8.jar:/Users/cvalentine/repositories/VarDictJava/build/install/VarDict/lib/commons-cli-1.2.jar:/Users/cvalentine/repositories/VarDictJava/build/install/VarDict/lib/jregex-1.2_01.jar:/Users/cvalentine/repositories/VarDictJava/build/install/VarDict/lib/htsjdk-2.8.0.jar com.astrazeneca.vardict.Main
```
