### PR TITLE
Added exceptions for FASTA and BED

### DIFF
--- a/src/main/java/com/astrazeneca/vardict/VarDictLauncher.java
+++ b/src/main/java/com/astrazeneca/vardict/VarDictLauncher.java
@@ -4,6 +4,7 @@ import com.astrazeneca.vardict.collection.Tuple;
 import com.astrazeneca.vardict.data.ReferenceResource;
 import com.astrazeneca.vardict.data.Region;
 import com.astrazeneca.vardict.data.scopedata.GlobalReadOnlyScope;
+import com.astrazeneca.vardict.exception.RegionMissedSourceException;
 import com.astrazeneca.vardict.modes.*;
 import htsjdk.samtools.SAMFileHeader;
 import htsjdk.samtools.SAMSequenceRecord;
@@ -73,6 +74,9 @@ public class VarDictLauncher {
      */
     private void initResources(Configuration conf) {
         try {
+            if (conf.regionOfInterest == null && conf.bed == null) {
+                throw new RegionMissedSourceException();
+            }
             Map<String, Integer> chrLengths = readChr(conf.bam.getBamX());
             Tuple.Tuple2<String, String> samples;
             if ((conf.regionOfInterest != null) && (conf.bam.hasBam2())) {

--- a/src/main/java/com/astrazeneca/vardict/data/Patterns.java
+++ b/src/main/java/com/astrazeneca/vardict/data/Patterns.java
@@ -158,4 +158,7 @@ public class Patterns {
     public static final jregex.Pattern BEGIN_NUM_S_OR_BEGIN_NUM_H = new jregex.Pattern("^(\\d+)S|^\\d+H");
     public static final jregex.Pattern END_NUM_S_OR_NUM_H = new jregex.Pattern("(\\d+)S$|H$");
 
+    //Exception patterns
+    public static final Pattern UNABLE_FIND_CONTIG = Pattern.compile("Unable to find entry for contig");
+    public static final Pattern WRONG_START_OR_END = Pattern.compile("Malformed query");
 }

--- a/src/main/java/com/astrazeneca/vardict/exception/RegionBoundariesException.java
+++ b/src/main/java/com/astrazeneca/vardict/exception/RegionBoundariesException.java
@@ -1,0 +1,14 @@
+package com.astrazeneca.vardict.exception;
+
+
+import java.util.Locale;
+
+public class RegionBoundariesException extends RuntimeException {
+    public final static String RegionBoundariesExceptionMessage = "The region %s:%d-%d is wrong. " +
+            "We have problem while reading it, possible the start is after the end of the region or " +
+            "the fasta doesn't contain this region.";
+
+    public RegionBoundariesException(String chr, int start, int end, Throwable e) {
+            super(String.format(Locale.US, RegionBoundariesExceptionMessage, chr, start, end) , e);
+    }
+}

--- a/src/main/java/com/astrazeneca/vardict/exception/RegionMissedSourceException.java
+++ b/src/main/java/com/astrazeneca/vardict/exception/RegionMissedSourceException.java
@@ -1,0 +1,11 @@
+package com.astrazeneca.vardict.exception;
+
+
+public class RegionMissedSourceException extends RuntimeException {
+    public final static String RegionSourceMissedMessage = "The required BED file or region missed, please, set it " +
+            "with path to BED or with -R option.";
+
+    public RegionMissedSourceException() {
+            super(RegionSourceMissedMessage);
+    }
+}

--- a/src/main/java/com/astrazeneca/vardict/exception/WrongFastaOrBamException.java
+++ b/src/main/java/com/astrazeneca/vardict/exception/WrongFastaOrBamException.java
@@ -1,0 +1,14 @@
+package com.astrazeneca.vardict.exception;
+
+
+import java.util.Locale;
+
+public class WrongFastaOrBamException extends RuntimeException {
+    public final static String WrongFastaOrBamExceptionMeassage = "The name of this chromosome \"%s\" is missing in your" +
+            " fasta file. Please be sure that chromosome names in BAM, fasta and BED are in correspondence " +
+            "with each other and you use correct fasta for your BAM (can be checked in BAM header).";
+
+    public WrongFastaOrBamException(String chr, Throwable e) {
+            super(String.format(Locale.US, WrongFastaOrBamExceptionMeassage, chr), e);
+    }
+}

--- a/src/main/java/com/astrazeneca/vardict/modes/AbstractMode.java
+++ b/src/main/java/com/astrazeneca/vardict/modes/AbstractMode.java
@@ -147,4 +147,13 @@ public abstract class AbstractMode {
      */
     public abstract void printHeader();
 
+    public Reference tryToGetReference(Region region) {
+        Reference reference = new Reference();
+        try {
+            reference = referenceResource.getReference(region);
+        } catch (Exception ex) {
+            stopVardictWithException(region, ex);
+        }
+        return reference;
+    }
 }

--- a/src/main/java/com/astrazeneca/vardict/modes/AmpliconMode.java
+++ b/src/main/java/com/astrazeneca/vardict/modes/AmpliconMode.java
@@ -1,5 +1,6 @@
 package com.astrazeneca.vardict.modes;
 
+import com.astrazeneca.vardict.data.Reference;
 import com.astrazeneca.vardict.data.ReferenceResource;
 import com.astrazeneca.vardict.collection.ConcurrentHashSet;
 import com.astrazeneca.vardict.collection.DirectThreadExecutor;
@@ -58,7 +59,7 @@ public class AmpliconMode extends AbstractMode {
                     list.add(tuple(ampliconNumber, region));
                 }
                 Scope<InitialData> initialScope = new Scope<>(instance().conf.bam.getBam1(), region,
-                        referenceResource.getReference(region), referenceResource, 0, splice,
+                        tryToGetReference(region), referenceResource, 0, splice,
                         variantPrinter, new InitialData());
                 CompletableFuture<Scope<AlignedVarsData>> pipeline = pipeline(initialScope,
                         new DirectThreadExecutor());
@@ -93,8 +94,9 @@ public class AmpliconMode extends AbstractMode {
                             list.add(tuple(j, region));
                         }
                         VariantPrinter variantPrinter = VariantPrinter.createPrinter(instance().printerTypeOut);
+                        Reference reference = tryToGetReference(region);
                         Scope<InitialData> initialScope = new Scope<>(instance().conf.bam.getBam1(), region,
-                                referenceResource.getReference(region), referenceResource, 0, splice,
+                                reference, referenceResource, 0, splice,
                                 variantPrinter, new InitialData());
 
                         CompletableFuture<Scope<AlignedVarsData>> pipeline = pipeline(initialScope, executor);

--- a/src/main/java/com/astrazeneca/vardict/modes/SimpleMode.java
+++ b/src/main/java/com/astrazeneca/vardict/modes/SimpleMode.java
@@ -95,9 +95,9 @@ public class SimpleMode extends AbstractMode {
      * @param out variant printer used for output
      */
     private void processBamInPipeline(Region region, VariantPrinter out) {
-        Reference ref = referenceResource.getReference(region);
+        Reference reference = tryToGetReference(region);
         Scope<InitialData> initialScope = new Scope<>(instance().conf.bam.getBam1(), region,
-                ref, referenceResource, 0, new HashSet<>(),
+                reference, referenceResource, 0, new HashSet<>(),
                 out, new InitialData());
 
         CompletableFuture<Scope<AlignedVarsData>> pipeline = pipeline(initialScope, new DirectThreadExecutor());

--- a/src/main/java/com/astrazeneca/vardict/modes/SomaticMode.java
+++ b/src/main/java/com/astrazeneca/vardict/modes/SomaticMode.java
@@ -45,7 +45,7 @@ public class SomaticMode extends AbstractMode {
         for (List<Region> list : segments) {
             for (Region region : list) {
                 final Set<String> splice = new ConcurrentHashSet<>();
-                Reference ref = referenceResource.getReference(region);
+                Reference ref = tryToGetReference(region);
                 processBothBamsInPipeline(variantPrinter, region, splice, ref);
             }
         }
@@ -62,7 +62,7 @@ public class SomaticMode extends AbstractMode {
                 for (List<Region> list : segments) {
                     for (Region region : list) {
                         final Set<String> splice = new ConcurrentHashSet<>();
-                        Reference ref1 = referenceResource.getReference(region);
+                        Reference ref1 = tryToGetReference(region);
                         Future<OutputStream> f2 = executor.submit(new SomdictWorker(region, splice, ref1));
                         toPrint.put(f2);
                     }

--- a/src/main/java/com/astrazeneca/vardict/modes/SplicingMode.java
+++ b/src/main/java/com/astrazeneca/vardict/modes/SplicingMode.java
@@ -51,9 +51,9 @@ public class SplicingMode extends AbstractMode {
      * @param out variant printer used for output
      */
     private void processRegion(Region region, VariantPrinter out) {
-        Reference ref = referenceResource.getReference(region);
+        Reference reference = tryToGetReference(region);
         Scope<InitialData> initialScope = new Scope<>(instance().conf.bam.getBam1(), region,
-                ref, referenceResource, 0, new HashSet<>(),
+                reference, referenceResource, 0, new HashSet<>(),
                 out, new InitialData());
 
         CompletableFuture<Scope<VariationData>> pipeline = splicingPipeline(initialScope, new DirectThreadExecutor());


### PR DESCRIPTION
### Description
* Added handling for htsjdk SAMException while parsing fasta: wrapped with a more clear description.
* Added stop of VarDict if SAMException for reference occurs in multithread mode.
* Added check for BED or region: if none of them was set, the exception will be thrown.