### PR TITLE
Fixed issue 267: IUPAC ambiguity codes in reference

### DIFF
--- a/src/main/java/com/astrazeneca/vardict/modules/ToVarsBuilder.java
+++ b/src/main/java/com/astrazeneca/vardict/modules/ToVarsBuilder.java
@@ -993,9 +993,19 @@ public class ToVarsBuilder implements Module<RealignedVariationData, AlignedVars
         }
     }
 
+    /**
+     * Validate reference allele according to VCF 4.3 specification in case if IUPAC ambiguity codes are present
+     * in reference.
+     * @param refallele sequence of reference bases that covers variant
+     * @return reference allele sequence where IUPAC ambuguity bases are changed to the one that is
+     * first alphabetically.
+     */
     String validateRefallele(String refallele) {
-        if (IUPAC_AMBIGUITY_CODES.containsKey(refallele)){
-            refallele = IUPAC_AMBIGUITY_CODES.get(refallele);
+        for (int i = 0; i < refallele.length(); i++) {
+            String refBase = substr(refallele, i, 1);
+            if (IUPAC_AMBIGUITY_CODES.containsKey(refBase)) {
+                refallele = refallele.replaceFirst(refBase, IUPAC_AMBIGUITY_CODES.get(refBase));
+            }
         }
         return refallele;
     }

--- a/src/main/java/com/astrazeneca/vardict/postprocessmodules/SimplePostProcessModule.java
+++ b/src/main/java/com/astrazeneca/vardict/postprocessmodules/SimplePostProcessModule.java
@@ -65,6 +65,11 @@ public class SimplePostProcessModule implements Consumer<Scope<AlignedVarsData>>
                         if (vref.refallele.contains("N")) {
                             continue;
                         }
+                        if (vref.refallele.equals(vref.varallele)) {
+                            if (!conf.doPileup) {
+                                continue;
+                            }
+                        }
                         vref.vartype = vref.varType();
                         if (!vref.isGoodVar(variantsOnPosition.referenceVariant, vref.vartype, mapScope.splice)) {
                             if (!conf.doPileup) {

--- a/src/test/java/com/astrazeneca/vardict/modules/ToVarsBuilderTest.java
+++ b/src/test/java/com/astrazeneca/vardict/modules/ToVarsBuilderTest.java
@@ -11,10 +11,7 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static org.testng.Assert.assertEquals;
 
@@ -131,5 +128,16 @@ public class ToVarsBuilderTest {
         }};
 
         assertEquals(var.get(0).toString(), expectedVariant.toString());
+    }
+
+    @Test
+    public void testValidateRefAllele(){
+        List<String> alleles = Arrays.asList("A", "C", "G", "T", "N", "M", "R", "W", "S", "Y", "K", "V", "H", "D", "B");
+        List<String> expected = Arrays.asList("A", "C", "G", "T", "N", "A", "A", "A", "C", "C", "G", "A", "A", "A", "C");
+        List<String> validatedAlleles = new ArrayList<>();
+        for (String allele: alleles) {
+            validatedAlleles.add(toVarsBuilder.validateRefallele(allele));
+        }
+        assertEquals(validatedAlleles, expected);
     }
 }

--- a/src/test/java/com/astrazeneca/vardict/modules/ToVarsBuilderTest.java
+++ b/src/test/java/com/astrazeneca/vardict/modules/ToVarsBuilderTest.java
@@ -139,5 +139,14 @@ public class ToVarsBuilderTest {
             validatedAlleles.add(toVarsBuilder.validateRefallele(allele));
         }
         assertEquals(validatedAlleles, expected);
+
+        List<String> alleles_complex = Arrays.asList("ANYCGT", "MRACT", "CCGKBG");
+        List<String> expected_complex = Arrays.asList("ANCCGT", "AAACT", "CCGGCG");
+
+        validatedAlleles = new ArrayList<>();
+        for (String allele: alleles_complex) {
+            validatedAlleles.add(toVarsBuilder.validateRefallele(allele));
+        }
+        assertEquals(validatedAlleles, expected_complex);
     }
 }


### PR DESCRIPTION
### Description
* Fixed issue #267. Added validation of reference base (REF field): in case when REF contains bases with IUPAC ambiguity code, then such bases will be changed to the one that is first alphabetically (as in spec: https://samtools.github.io/hts-specs/VCFv4.3.pdf).
* For pileup mode (gVCF like) when REF and ALT can be the same, ALT also will be updated as REF.  
* Added test.
* Updated submodule VarDict.