### PR TITLE
Update HTSJDK to a more modern version and fix a typo.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -92,7 +92,7 @@ Currently, the project uses the following third-party libraries:
 * JRegex (http://jregex.sourceforge.net, BSD license) is a regular expressions library that is used instead of the 
 standard Java library because its performance is much higher than that of the standard library.
 * Commons CLI (http://commons.apache.org/proper/commons-cli, Apache License) – a library for parsing the command line.
-* HTSJDK (http://smtools.github.io/htsjdk/) is an implementation of a unified Java library for accessing common file formats, such as SAM and VCF.
+* HTSJDK (http://samtools.github.io/htsjdk/) is an implementation of a unified Java library for accessing common file formats, such as SAM and VCF.
 * Mockito and TestNG are the testing frameworks (not included in distribution, used only in tests).
 
 ### Single sample mode

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     compile 'commons-cli:commons-cli:1.2' 
     compile 'org.apache.commons:commons-math3:3.6.1'
     compile 'com.edropple.jregex:jregex:1.2_01'
-    compile('com.github.samtools:htsjdk:2.8.0') {
+    compile('com.github.samtools:htsjdk:2.21.1') {
         transitive = false
     }
     testCompile 'org.mockito:mockito-core:2.23.0'

--- a/src/main/java/com/astrazeneca/vardict/modules/RecordPreprocessor.java
+++ b/src/main/java/com/astrazeneca/vardict/modules/RecordPreprocessor.java
@@ -119,7 +119,7 @@ public class RecordPreprocessor {
         }
 
         //Skip not primary alignment reads
-        if (record.getNotPrimaryAlignmentFlag() && !instance().conf.samfilter.equals("0")) {
+        if (record.isSecondaryAlignment() && !instance().conf.samfilter.equals("0")) {
             return false;
         }
         // Skip reads where sequence is not stored in read


### PR DESCRIPTION
I noticed that this project is using a very old version of htsjdk, 2.8.0 is from 2016.  This PR updates it to a more modern one, I updated one line that used a newly deprecated htsjdk method.    It also fixes a typo in the readme. 