### PR TITLE
Fix issue where hardclipping adjacent to insertion/deletion results in index out of range error

### DIFF
--- a/src/main/java/com/astrazeneca/vardict/data/Patterns.java
+++ b/src/main/java/com/astrazeneca/vardict/data/Patterns.java
@@ -128,6 +128,11 @@ public class Patterns {
      */
     public static final Pattern ANY_NUMBER_M_NUMBER_S_END = Pattern.compile("^(.*?)(\\d+)M(\\d+)S$");
     /**
+     * Regexp finds number followed by H at the start of string
+     */
+    public static final jregex.Pattern BEGIN_NUMBER_H = new jregex.Pattern("^(\\d+)H");
+    public static final jregex.Pattern END_NUMBER_H = new jregex.Pattern("(\\d+)H$");
+    /**
      * Regexp finds number followed by D at the start of string
      */
     public static final jregex.Pattern BEGIN_NUMBER_D = new jregex.Pattern("^(\\d+)D");

--- a/src/main/java/com/astrazeneca/vardict/modules/CigarModifier.java
+++ b/src/main/java/com/astrazeneca/vardict/modules/CigarModifier.java
@@ -57,8 +57,20 @@ public class CigarModifier {
         //flag is set to true if CIGAR string is modified and should be looked at again
         boolean flag = true;
         try {
-            // if CIGAR starts with deletion cut it off
-            jregex.Matcher mm = BEGIN_NUMBER_D.matcher(cigarStr);
+            // if CIGAR starts or ends with hardclipping cut it off before further CIGAR mods
+            jregex.Matcher mm = BEGIN_NUMBER_H.matcher(cigarStr);
+            if (mm.find()) {
+                position += toInt(mm.group(1));
+                Replacer r = BEGIN_NUMBER_H.replacer("");
+                cigarStr = r.replace(cigarStr);
+            }
+            mm = END_NUMBER_H.matcher(cigarStr);
+            if (mm.find()) {
+                Replacer r = END_NUMBER_H.replacer("");
+                cigarStr = r.replace(cigarStr);
+            }
+            // if post-hardclipping removal CIGAR starts with deletion cut it off
+            mm = BEGIN_NUMBER_D.matcher(cigarStr);
             if (mm.find()) {
                 position += toInt(mm.group(1));
                 Replacer r = BEGIN_NUMBER_D.replacer("");
@@ -69,6 +81,7 @@ public class CigarModifier {
                 Replacer r = END_NUMBER_D.replacer("");
                 cigarStr = r.replace(cigarStr);
             }
+
             // replace insertion at the beginning and end with soft clipping
             mm = BEGIN_NUMBER_I.matcher(cigarStr);
             if (mm.find()) {


### PR DESCRIPTION
Proposed solution for issue #283 .  Solution is to remove hardclipping from CIGAR string prior to further CIGAR modifications.