### PR TITLE
Add support for single primer amplicon designs

### DIFF
--- a/src/main/java/com/astrazeneca/vardict/CmdParser.java
+++ b/src/main/java/com/astrazeneca/vardict/CmdParser.java
@@ -75,7 +75,7 @@ public class CmdParser {
             config.zeroBased = 1 == getIntValue(cmd, "z", 1);
         }
         config.ampliconBasedCalling = cmd.getOptionValue("a");
-        config.ampliconSinglePrimer = cmd.getBooleanValue("sp", true);
+        config.ampliconSinglePrimer = cmd.hasOption("sp");
         config.performLocalRealignment = 1 == getIntValue(cmd, "k", 1);
 
         config.fasta = setFastaFile(cmd);

--- a/src/main/java/com/astrazeneca/vardict/CmdParser.java
+++ b/src/main/java/com/astrazeneca/vardict/CmdParser.java
@@ -75,7 +75,7 @@ public class CmdParser {
             config.zeroBased = 1 == getIntValue(cmd, "z", 1);
         }
         config.ampliconBasedCalling = cmd.getOptionValue("a");
-        config.ampliconSinglePrimer = cmd.getOptionValue("sp");
+        config.ampliconSinglePrimer = cmd.getBooleanValue("sp", true);
         config.performLocalRealignment = 1 == getIntValue(cmd, "k", 1);
 
         config.fasta = setFastaFile(cmd);

--- a/src/main/java/com/astrazeneca/vardict/CmdParser.java
+++ b/src/main/java/com/astrazeneca/vardict/CmdParser.java
@@ -75,6 +75,7 @@ public class CmdParser {
             config.zeroBased = 1 == getIntValue(cmd, "z", 1);
         }
         config.ampliconBasedCalling = cmd.getOptionValue("a");
+        config.ampliconSinglePrimer = cmd.getOptionValue("sp");
         config.performLocalRealignment = 1 == getIntValue(cmd, "k", 1);
 
         config.fasta = setFastaFile(cmd);
@@ -235,6 +236,7 @@ public class CmdParser {
         options.addOption("deldupvar", false, "Turn on deleting of duplicate variants. Variants in this mode are considered and outputted only if start position of variant is inside the region interest.");
         options.addOption("fisher", false, "Experimental feature: Changes R script (teststrandbias.R and testsomatic.) to Java implementation of Fisher exact test.");
         options.addOption("U", "nosv", false, "Turn off structural variant calling.");
+        options.addOption("sp", false, "Indicate to turn on single primer amplicon mode.  Must also specify -a.");
 
         options.addOption(OptionBuilder.withArgName("bit")
                 .hasArg(true)

--- a/src/main/java/com/astrazeneca/vardict/Configuration.java
+++ b/src/main/java/com/astrazeneca/vardict/Configuration.java
@@ -39,6 +39,10 @@ public class Configuration {
      * and overlap fraction is at least float. Default: 10:0.95
      */
     public String ampliconBasedCalling; //-a
+    /**
+     * Indicate we have a single primer design.  Primer may be oriented in either the reverse or forward direction.
+     */
+    public Boolean ampliconSinglePrimer; //-sp
 
     public int columnForChromosome = -1; //-c
 

--- a/src/main/java/com/astrazeneca/vardict/modules/CigarParser.java
+++ b/src/main/java/com/astrazeneca/vardict/modules/CigarParser.java
@@ -1305,7 +1305,7 @@ public class CigarParser implements Module<RecordPreprocessor, VariationData> {
      */
     private boolean parseCigarWithAmpCase(SAMRecord record, boolean isMateReferenceNameEqual) {
         String[] split = instance().ampliconBasedCalling.split(":");
-        boolean sp = instance().ampliconSinglePrimer;
+        boolean sp = instance().conf.ampliconSinglePrimer;
         // Distance to amplicon (specified in -a option)
         int distanceToAmplicon;
         // Overlap fraction (in -a option)

--- a/src/main/java/com/astrazeneca/vardict/modules/CigarParser.java
+++ b/src/main/java/com/astrazeneca/vardict/modules/CigarParser.java
@@ -1355,9 +1355,7 @@ public class CigarParser implements Module<RecordPreprocessor, VariationData> {
             // Ignore reads that are more than distance from region of interest
             // and overlap is less than overlap fraction from configuration (-a)
             // JL: Only have one primer, so we just want to check one side or the other, but not both.
-            if (abs(segstart - region.start) <= distanceToAmplicon) && (ts1 / (double)(segstart) > overlapFraction) {
-            } else if (abs(segend - region.end) <= distanceToAmplicon) && (te1 / (double)(segend) > overlapFraction) {
-            } else {
+            if ((abs(segstart - region.start) > distanceToAmplicon) && (ts1 / (double)(segstart) <= overlapFraction)) || ((abs(segend - region.end) > distanceToAmplicon) && (te1 / (double)(segend) <= overlapFraction)) {
                 return true;
             }
         }

--- a/src/main/java/com/astrazeneca/vardict/modules/CigarParser.java
+++ b/src/main/java/com/astrazeneca/vardict/modules/CigarParser.java
@@ -1354,10 +1354,19 @@ public class CigarParser implements Module<RecordPreprocessor, VariationData> {
             int te1 = segend < region.end ? segend : region.end;
             // Ignore reads that are more than distance from region of interest
             // and overlap is less than overlap fraction from configuration (-a)
-            // JL: Only have one primer, so we just want to check one side or the other, but not both.
-            if ((abs(segstart - region.start) <= distanceToAmplicon) || (abs(segend - region.end) <= distanceToAmplicon)) {
-                return false;
+            // JL: If ampliconSinglePrimer option has been selected,
+            // just want to check one side or the other, but not both.
+            if (instance().ampliconSinglePrimer == true) {
+                if ((abs(segstart - region.start) <= distanceToAmplicon) || (abs(segend - region.end) <= distanceToAmplicon)) {
+                    return false;
+                }
             }
+            else {
+                if ((abs(segstart - region.start) > distanceToAmplicon || abs(segend - region.end) > distanceToAmplicon) || abs((ts1 - te1) / (double)(segend - segstart)) <= overlapFraction) {
+                    return true;
+                }
+            }
+
         }
         return false;
     }

--- a/src/main/java/com/astrazeneca/vardict/modules/CigarParser.java
+++ b/src/main/java/com/astrazeneca/vardict/modules/CigarParser.java
@@ -1355,10 +1355,7 @@ public class CigarParser implements Module<RecordPreprocessor, VariationData> {
             // Ignore reads that are more than distance from region of interest
             // and overlap is less than overlap fraction from configuration (-a)
             // JL: Only have one primer, so we just want to check one side or the other, but not both.
-//             if (((abs(segstart - region.start) > distanceToAmplicon) && (ts1 / (double)(segstart) <= overlapFraction)) || ((abs(segend - region.end) > distanceToAmplicon) && (te1 / (double)(segend) <= overlapFraction))) {
-//                 return true;
-//             }
-            if (((abs(segstart - region.start) <= distanceToAmplicon) || ((abs(segend - region.end) <= distanceToAmplicon)) {
+            if ((abs(segstart - region.start) <= distanceToAmplicon) || (abs(segend - region.end) <= distanceToAmplicon)) {
                 return false;
             }
         }

--- a/src/main/java/com/astrazeneca/vardict/modules/CigarParser.java
+++ b/src/main/java/com/astrazeneca/vardict/modules/CigarParser.java
@@ -1355,8 +1355,11 @@ public class CigarParser implements Module<RecordPreprocessor, VariationData> {
             // Ignore reads that are more than distance from region of interest
             // and overlap is less than overlap fraction from configuration (-a)
             // JL: Only have one primer, so we just want to check one side or the other, but not both.
-            if (((abs(segstart - region.start) > distanceToAmplicon) && (ts1 / (double)(segstart) <= overlapFraction)) || ((abs(segend - region.end) > distanceToAmplicon) && (te1 / (double)(segend) <= overlapFraction))) {
-                return true;
+//             if (((abs(segstart - region.start) > distanceToAmplicon) && (ts1 / (double)(segstart) <= overlapFraction)) || ((abs(segend - region.end) > distanceToAmplicon) && (te1 / (double)(segend) <= overlapFraction))) {
+//                 return true;
+//             }
+            if (((abs(segstart - region.start) <= distanceToAmplicon) || ((abs(segend - region.end) <= distanceToAmplicon) {
+                return false;
             }
         }
         return false;

--- a/src/main/java/com/astrazeneca/vardict/modules/CigarParser.java
+++ b/src/main/java/com/astrazeneca/vardict/modules/CigarParser.java
@@ -1358,7 +1358,7 @@ public class CigarParser implements Module<RecordPreprocessor, VariationData> {
 //             if (((abs(segstart - region.start) > distanceToAmplicon) && (ts1 / (double)(segstart) <= overlapFraction)) || ((abs(segend - region.end) > distanceToAmplicon) && (te1 / (double)(segend) <= overlapFraction))) {
 //                 return true;
 //             }
-            if (((abs(segstart - region.start) <= distanceToAmplicon) || ((abs(segend - region.end) <= distanceToAmplicon) {
+            if (((abs(segstart - region.start) <= distanceToAmplicon) || ((abs(segend - region.end) <= distanceToAmplicon)) {
                 return false;
             }
         }

--- a/src/main/java/com/astrazeneca/vardict/modules/CigarParser.java
+++ b/src/main/java/com/astrazeneca/vardict/modules/CigarParser.java
@@ -1355,7 +1355,7 @@ public class CigarParser implements Module<RecordPreprocessor, VariationData> {
             // Ignore reads that are more than distance from region of interest
             // and overlap is less than overlap fraction from configuration (-a)
             // JL: Only have one primer, so we just want to check one side or the other, but not both.
-            if ((abs(segstart - region.start) > distanceToAmplicon) && (ts1 / (double)(segstart) <= overlapFraction)) || ((abs(segend - region.end) > distanceToAmplicon) && (te1 / (double)(segend) <= overlapFraction)) {
+            if (((abs(segstart - region.start) > distanceToAmplicon) && (ts1 / (double)(segstart) <= overlapFraction)) || ((abs(segend - region.end) > distanceToAmplicon) && (te1 / (double)(segend) <= overlapFraction))) {
                 return true;
             }
         }

--- a/src/main/java/com/astrazeneca/vardict/modules/CigarParser.java
+++ b/src/main/java/com/astrazeneca/vardict/modules/CigarParser.java
@@ -1354,8 +1354,10 @@ public class CigarParser implements Module<RecordPreprocessor, VariationData> {
             int te1 = segend < region.end ? segend : region.end;
             // Ignore reads that are more than distance from region of interest
             // and overlap is less than overlap fraction from configuration (-a)
-            if ((abs(segstart - region.start) > distanceToAmplicon || abs(segend - region.end) > distanceToAmplicon)
-                    || abs((ts1 - te1) / (double)(segend - segstart)) <= overlapFraction) {
+            // JL: Only have one primer, so we just want to check one side or the other, but not both.
+            if (abs(segstart - region.start) <= distanceToAmplicon) && (ts1 / (double)(segstart) > overlapFraction) {
+            } else if (abs(segend - region.end) <= distanceToAmplicon) && (te1 / (double)(segend) > overlapFraction) {
+            } else {
                 return true;
             }
         }

--- a/src/main/java/com/astrazeneca/vardict/modules/CigarParser.java
+++ b/src/main/java/com/astrazeneca/vardict/modules/CigarParser.java
@@ -1305,6 +1305,7 @@ public class CigarParser implements Module<RecordPreprocessor, VariationData> {
      */
     private boolean parseCigarWithAmpCase(SAMRecord record, boolean isMateReferenceNameEqual) {
         String[] split = instance().ampliconBasedCalling.split(":");
+        boolean sp = instance().ampliconSinglePrimer;
         // Distance to amplicon (specified in -a option)
         int distanceToAmplicon;
         // Overlap fraction (in -a option)
@@ -1356,7 +1357,7 @@ public class CigarParser implements Module<RecordPreprocessor, VariationData> {
             // and overlap is less than overlap fraction from configuration (-a)
             // JL: If ampliconSinglePrimer option has been selected,
             // just want to check one side or the other, but not both.
-            if (instance().ampliconSinglePrimer == true) {
+            if (sp) {
                 if ((abs(segstart - region.start) <= distanceToAmplicon) || (abs(segend - region.end) <= distanceToAmplicon)) {
                     return false;
                 }


### PR DESCRIPTION
For designs such as QIAseq (single primer extension), you can't filter reads that don't match both start and end, since you only expect to see either a primer at the start or on the end.  This PR adds the -sp option to filter reads only if there is no match between either the start or end, but does not require both. 